### PR TITLE
added zeromq client functionality

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gem 'yard',          '~> 0.8.5'
 gem 'rake',          '~> 0.9'
 gem 'awesome_print', '~> 1.1.0'
 gem 'redcarpet'
+gem 'faraday-zeromq', :git => 'git@github.com:technoweenie/faraday-zeromq.git'
 
 group :development, :test do
   gem 'pry'

--- a/farscape.gemspec
+++ b/farscape.gemspec
@@ -22,4 +22,5 @@ Gem::Specification.new do |s|
   s.add_dependency('addressable',   '~> 2.3.0')
   s.add_dependency('dice_bag',      '~> 0.7.0')
   s.add_dependency('faraday',       '~> 0.8.8')
+  s.add_dependency('ffi-rzmq',      '~> 2.0.1')
 end

--- a/lib/farscape/agent.rb
+++ b/lib/farscape/agent.rb
@@ -1,5 +1,6 @@
 require 'farscape/helpers'
 require 'farscape/agent/http_client'
+require 'farscape/agent/zeromq_client'
 require 'farscape/agent/request'
 
 module Farscape

--- a/lib/farscape/agent/base_client.rb
+++ b/lib/farscape/agent/base_client.rb
@@ -26,7 +26,7 @@ module Farscape
       # @param [Hash] options Optional Faraday configuration.
       def initialize(options = {})
         @connection = Faraday.new(options) do |faraday|
-          faraday.adapter default_adapter
+          faraday.adapter *default_adapter
           yield faraday if block_given?
         end
       end
@@ -52,11 +52,15 @@ module Farscape
       end
 
       def transmit(request)
-        request_connection = request.connection || connection
+        request_connection = transmit_connection(request)
         request_env = request.to_env(request_connection)
         request_env = serialize_body(request_env)
         response = request_connection.app.call(request_env)
         Result.new(request, response)
+      end
+      
+      def transmit_connection(request)
+        request.connection || connection
       end
       
       def serialize_body(env)

--- a/lib/farscape/agent/request.rb
+++ b/lib/farscape/agent/request.rb
@@ -37,8 +37,12 @@ module Farscape
         self.frozen?
       end
       
+      def origin
+        uri.origin if uri
+      end
+      
       def scheme
-        @scheme ||= if uri = Addressable::URI.parse(url)
+        @scheme ||= if uri
           uri.scheme.downcase.to_sym if uri.scheme
         end 
       end
@@ -52,6 +56,10 @@ module Farscape
       
       def to_hash
         ATTRIBUTES.each_with_object({}) { |attribute, h| h[attribute] = send(attribute) }
+      end
+      
+      def uri
+        Addressable::URI.parse(url)
       end
 
       def url=(value)

--- a/lib/farscape/agent/zeromq_client.rb
+++ b/lib/farscape/agent/zeromq_client.rb
@@ -1,0 +1,30 @@
+require 'farscape/agent/base_client'
+require 'ffi-rzmq'
+require 'faraday-zeromq'
+
+module Farscape
+  class Agent
+    class ZeromqClient < BaseClient
+      schemes :tcp
+      
+      private
+      def default_adapter
+        :zeromq
+      end
+      
+      def transmit_connection(request)
+        request.connection || Faraday.new(builder: connection_builder(request)) 
+      end
+      
+      def connection_builder(request)
+        context = ZMQ::Context.new
+        socket = context.socket(ZMQ::REQ).tap { |s| s.connect(request.origin) }
+        
+        connection.builder.dup.tap do |builder|
+          builder.handlers.pop #remove adapter
+          builder.adapter default_adapter, socket, YAML # TODO: look at different serializer options
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/farscape/agent/zeromq_client_spec.rb
+++ b/spec/lib/farscape/agent/zeromq_client_spec.rb
@@ -1,0 +1,100 @@
+require 'spec_helper'
+require 'farscape/agent/zeromq_client'
+
+module Farscape
+  class Agent
+    describe ZeromqClient do
+      # Note: This class is copied from faraday-zeromq, but not used completely at this point as we are not trying
+      # to test the faraday adapter. However, in the future, this may be useful for more detailed testing.
+      class FakeSocket
+        attr_reader :sent
+
+        def initialize(responses)
+          @sent = []
+          @responses = responses.empty? ? [YAML.dump([200, {}]), 'ok'] : responses
+        end
+
+        def send_string(str, flags = 0)
+          @sent << [str, flags]
+        end
+
+        def recv_string(s)
+          s.replace @responses.shift
+        end
+
+        def connect(*); end # Do nothing
+      end
+      
+      def build_socket(meta = nil, body = nil)
+        FakeSocket.new(meta ? [YAML.dump(meta), body] : [])
+      end
+
+      let(:config) { Farscape::Configuration.config }
+
+      after do
+        Farscape.send(:reset_config)
+      end
+
+      it 'self registers itself in the client factory' do
+        client_factory = config.client_factory
+        client_factory.registered_classes[:tcp].should == ZeromqClient
+      end
+
+      describe '#invoke' do
+        let(:subject) { ZeromqClient.new }
+        let(:options) do
+          {
+            url: 'tcp://127.0.0.1:1',
+            method: 'POST',
+            params: {page: 1, per_page: 2},
+            headers: {'Content-Type' => 'application/json'},
+            body: {name: "Ka D'Argo"},
+            connection_options: {some: 'options'},
+            env_options: {add_to: 'rack_env'}
+          }
+        end
+
+        it 'raises an error for an invalid argument' do
+          expect { subject.invoke(double('invalid_argument')) }.to raise_error(ArgumentError)
+        end
+
+        context 'with valid arguments' do
+          before do
+            context = double('context')
+            context.stub(:socket).with(anything).and_return(build_socket)
+            ZMQ::Context.stub(:new).and_return(context)
+          end
+
+          context 'with a hash containing request parameters' do
+            it 'transmits a request' do
+              subject.invoke(options).should be_instance_of(Result)
+            end
+          end
+
+          context 'with a request object argument' do
+            it 'transmits a request' do
+              request = Request.new(options)
+              subject.invoke(request).should be_instance_of(Result)
+            end
+          end
+
+          context 'with a block' do
+            it 'transmits a request' do
+              response = subject.invoke do |builder|
+                builder.url = options[:url]
+                builder.method = options[:method]
+                builder.params = options[:params]
+                builder.headers = options[:headers]
+                builder.body = options[:body]
+                builder.env_options = options[:env_options]
+                builder.connection_options = options[:connection_options]
+              end
+
+              response.should be_instance_of(Result)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/farscape/agent_spec.rb
+++ b/spec/lib/farscape/agent_spec.rb
@@ -5,42 +5,62 @@ module Farscape
   describe Agent do 
     let(:agent) { Agent.new }
     let(:http_client) { double('http_client') }
+    let(:tcp_client) { double('tcp_client')}
     let(:config) { Farscape::Configuration.config }
-    let(:options) { { url: 'http://example.org' } }
+    let(:options) { { url: @url } }
     let(:request) { Agent::Request.new(options) }
      
     describe '#invoke' do
       context 'with valid arguments' do
-        context 'with known scheme' do
-          it 'defaults to using an HTTP client if no clients are configured' do
-            config.client_factory.stub(:build).with(:http).and_return(http_client)
-            http_client.should_receive(:invoke).with(request)
+        it 'defaults to using an HTTP client if no clients are configured' do
+          @url = 'http://example.org'
+          config.client_factory.stub(:build).with(:http).and_return(http_client)
+          http_client.should_receive(:invoke).with(request)
+          agent.invoke(request)
+        end
+        
+        shared_examples_for 'a request with a known scheme' do
+          before do
+            config.stub(:clients).and_return({http: http_client, tcp: tcp_client})
+          end
+          
+          it 'delegates the request to the underlying scheme client' do
+            client.should_receive(:invoke).with(request)
             agent.invoke(request)
           end
           
-          context 'with configured clients' do
-            before do
-              config.stub(:clients).and_return({ http: http_client })
-            end
-            
-            it 'delegates the request to the underlying scheme client' do
-              http_client.should_receive(:invoke).with(request)
-              agent.invoke(request)
-            end
-            
-            it 'builds a request from the options delegates the request to the underlying scheme client' do
-              agent.invoke(options) do |request|
-                http_client.should_receive(:invoke).with(request)
-              end
-            end
-  
-            it 'yields a request and delegates the request to the underlying scheme client' do
-              agent.invoke do |request|
-                request.url = 'http://example.org'
-                http_client.should_receive(:invoke).with(request)
-              end
+          it 'builds a request from the options delegates the request to the underlying scheme client' do
+            agent.invoke(options) do |request|
+              client.should_receive(:invoke).with(request)
             end
           end
+
+          it 'yields a request and delegates the request to the underlying scheme client' do
+            agent.invoke do |request|
+              request.url = @url
+              client.should_receive(:invoke).with(request)
+            end
+          end
+        end
+        
+        context 'with http scheme' do
+          let(:client) { http_client }
+          
+          before do
+            @url = 'http://example.org'
+          end
+
+          it_behaves_like 'a request with a known scheme'
+        end
+
+        context 'with tcp scheme' do
+          let(:client) { tcp_client }
+
+          before do
+            @url = 'tcp://1.2.3.4:5678'
+          end
+
+          it_behaves_like 'a request with a known scheme'
         end
         
         context 'without known scheme' do


### PR DESCRIPTION
@sheavalentine-mdsol @brutski @pservedio Please review and merge.

This PR adds dynamic functionality to swap scheme clients based on the scheme URL passed to a request. A future PR will make this more bulletproof scalable and reuse connections better.

I am adding a rake task in the demo service to allow socket communication as well.
