### PR TITLE
Implement Contentious Stipped Down Interface

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ group :development, :test do
   gem 'pry'
   #TODO replace both crichton and crichton_test_service with references to stable branches when ready.
   gem 'crichton_test_service', git: 'https://www.github.com/mdsol/moya.git', branch: 'develop'
-  gem 'crichton', git: 'https://www.github.com/mdsol/crichton.git', branch: 'develop'
+  gem 'crichton', git: 'https://www.github.com/mdsol/crichton.git', branch: 'develop' 
 end
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 gemspec
 
-gem 'byebug', '~> 3.5.1'
+gem 'byebug', '~> 3.5.1' if RUBY_VERSION > '2'
 gem 'yard',          '~> 0.8.5'
 gem 'rake',          '~> 0.9'
 gem 'awesome_print', '~> 1.1.0'
@@ -13,7 +13,7 @@ group :development, :test do
   gem 'pry'
   #TODO replace both crichton and crichton_test_service with references to stable branches when ready.
   gem 'crichton_test_service', git: 'https://www.github.com/mdsol/moya.git', branch: 'develop'
-  gem 'crichton', git: 'https://www.github.com/mdsol-share/crichton.git', branch: 'develop' 
+  gem 'crichton', git: 'https://www.github.com/mdsol-share/crichton.git', branch: 'develop'
 end
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ group :development, :test do
   gem 'pry'
   #TODO replace both crichton and crichton_test_service with references to stable branches when ready.
   gem 'crichton_test_service', git: 'https://www.github.com/mdsol/moya.git', branch: 'develop'
-  gem 'crichton', git: 'https://www.github.com/mdsol/crichton.git', branch: 'develop' 
+  gem 'crichton', git: 'https://www.github.com/mdsol-share/crichton.git', branch: 'develop' 
 end
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gem 'representors', git: 'https://www.github.com/mdsol-share/representors.git', 
 group :development, :test do
   gem 'pry'
   #TODO replace both crichton and crichton_test_service with references to stable branches when ready.
-  gem 'crichton_test_service', git: 'git@github.com:csavage-mdsol/crichton_test_service.git', branch: 'develop'
+  gem 'crichton_test_service', git: 'git@github.com:mdsol/moya.git', branch: 'develop'
   gem 'crichton', git: 'git@github.com:mdsol/crichton.git', branch: 'develop'
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ group :development, :test do
   gem 'pry'
   #TODO replace both crichton and crichton_test_service with references to stable branches when ready.
   gem 'crichton_test_service', git: 'https://www.github.com/mdsol/moya.git', branch: 'develop'
-  gem 'crichton', git: 'git@github.com:mdsol/crichton.git', branch: 'develop'
+  gem 'crichton', git: 'https://www.github.com/mdsol/crichton.git', branch: 'develop'
 end
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gem 'representors', git: 'https://www.github.com/mdsol-share/representors.git', 
 group :development, :test do
   gem 'pry'
   #TODO replace both crichton and crichton_test_service with references to stable branches when ready.
-  gem 'crichton_test_service', git: 'git@github.com:mdsol/moya.git', branch: 'develop'
+  gem 'crichton_test_service', git: 'https://www.github.com/mdsol/moya.git', branch: 'develop'
   gem 'crichton', git: 'git@github.com:mdsol/crichton.git', branch: 'develop'
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem 'rake',          '~> 0.9'
 gem 'awesome_print', '~> 1.1.0'
 gem 'redcarpet'
 
-gem 'representors', git: 'https://www.github.com/mdsol-share/representors.git', branch: '0-0-stable'
+gem 'representors', git: 'https://www.github.com/mdsol-share/representors.git', branch: 'develop'
 
 group :development, :test do
   gem 'pry'

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 gemspec
 
-gem 'debugger',      '~> 1.6.6'
+gem 'byebug', '~> 3.5.1'
 gem 'yard',          '~> 0.8.5'
 gem 'rake',          '~> 0.9'
 gem 'awesome_print', '~> 1.1.0'

--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem 'rake',          '~> 0.9'
 gem 'awesome_print', '~> 1.1.0'
 gem 'redcarpet'
 
-gem 'representors', git: 'https://www.github.com/mdsol-share/representors.git', branch: 'develop'
+gem 'representors', git: 'https://www.github.com/mdsol-share/representors.git', branch: '0-0-stable'
 
 group :development, :test do
   gem 'pry'

--- a/lib/farscape/representor.rb
+++ b/lib/farscape/representor.rb
@@ -6,7 +6,7 @@ module Farscape
     attr_reader :agent
     attr_reader :representor
 
-    # TODO: This is convoluted, we should probably just Monkeypatch things.
+    # TODO: Work with Representor to make this straight forwqrd.
     def initialize(requested_media_type, response_body, agent)
       @agent = agent
       if requested_media_type

--- a/lib/farscape/transition.rb
+++ b/lib/farscape/transition.rb
@@ -2,13 +2,13 @@ require 'representors'
 require 'ostruct'
 
 module Farscape
-  class Transition < Representors::Transition
+  class Transition
 
     EMPTY_BODIES = { hale: "{}" } #TODO: Fix Representor to allow nil resources
 
-    def initialize(transition_hash, agent)
+    def initialize(transition, agent)
       @agent = agent
-      super(transition_hash)
+      @transition = transition
     end
 
     def invoke
@@ -24,6 +24,10 @@ module Farscape
 
       response = @agent.client.invoke(call_options)
       Representor.new(@agent.media_type, response.body || EMPTY_BODIES[@agent.media_type], @agent)
+    end
+    
+    def method_missing(meth, *args, &block)
+      @transition.send(meth, *args, &block)
     end
   end
 end

--- a/lib/farscape/transition.rb
+++ b/lib/farscape/transition.rb
@@ -26,6 +26,7 @@ module Farscape
       Representor.new(@agent.media_type, response.body || EMPTY_BODIES[@agent.media_type], @agent)
     end
     
+    # TODO: Remove Constants from Representor Classes
     def method_missing(meth, *args, &block)
       @transition.send(meth, *args, &block)
     end

--- a/spec/lib/farscape/integration/interface_spec.rb
+++ b/spec/lib/farscape/integration/interface_spec.rb
@@ -2,6 +2,9 @@ require 'spec_helper'
 require 'json'
 
 describe Farscape::Representor do
+  
+  # TODO: Make Representor::Field behave like a string
+  
   let(:entry_point) { "http://localhost:#{RAILS_PORT}"}
   
   let(:drds_link) { Farscape::Agent.new(entry_point).enter.transitions["drds"] }
@@ -13,7 +16,8 @@ describe Farscape::Representor do
     and transitions (link/form affordances) for interacting with the resource representations.' do
       agent = Farscape::Agent.new(entry_point)
       resources = agent.enter
-      expect(resources.attributes).to eq({})  # TODO: Add an attribute to the Moya entry point
+      
+      expect(resources.attributes).to eq({})  # TODO: Make Crichton more flexible with Entry Points
       expect(resources.transitions.keys).to eq(["drds"]) # => TODO: Add leviathans to Moya
     end
   end
@@ -23,15 +27,15 @@ describe Farscape::Representor do
     
     it 'follow your nose entry to select a registered resource' do
       agent = Farscape::Agent.new(entry_point)
-      
       resources = agent.enter
+      
       expect(resources.transitions['drds'].invoke).to be_a Farscape::Representor
     end
     
     it 'immediately loading a discoverable resource if known to be registered in the service a priori.' do
       agent = Farscape::Agent.new
-      
       resources = agent.enter(entry_point)
+      
       expect(resources.transitions['drds'].invoke).to be_a Farscape::Representor
     end
     
@@ -52,6 +56,7 @@ describe Farscape::Representor do
         resources = agent.enter
         drds_transition = resources.transitions['drds']
         drds_resource = drds_transition.invoke { |req| req.parameters = can_do_hash } 
+
         expect(drds_resource.transitions['self'].uri).to eq(drds.transitions['self'].uri)
       end
     end
@@ -60,6 +65,7 @@ describe Farscape::Representor do
       it "can reload a resource" do
         self_transition = drds.transitions['self']
         reloaded_drds = self_transition.invoke
+
         expect(reloaded_drds.to_hash).to eq(drds.to_hash)
       end
     end
@@ -68,23 +74,25 @@ describe Farscape::Representor do
       describe "Apply Query Parameters" do
         it 'allows Application of Query Parameters' do
           search_transition = drds.transitions['search']
-          # Diverges from Doc do to doc not considering Field objects 
+
+          # TODO: Diverges from Doc due to doc not considering Field objects 
           expect(search_transition.parameters.map { |p| p.name } ).to eq(['search_term','search_name'])
           
           filtered_drds = search_transition.invoke do |builder|
-            builder.parameters = { search_term: '1812' }
+            builder.parameters = { search_term: '1812' } # TODO: Make Moya search like a normal person
           end
+
           expect(filtered_drds.transitions['items']).to_not be(nil)
         end
       end
 
       describe "Transform Resource State" do
         it 'allows Transformation of Resource State' do
-          embedded_drd_items = drds.embedded # Orig "drds.items" Looks like New Interface
-          
+          embedded_drd_items = drds.embedded # TODO: Orig "drds.items" Looks like New Interface          
           drd = embedded_drd_items['items'].first
+
           expect(drd.attributes.keys).to eq(['uuid','name','status','kind','leviathan_uuid','built_at'])
-          expect(drd.transitions.keys).to include("self", "update", "delete", "leviathan", "profile", "type", "help") # => ['self', 'edit', 'delete', 'deactivate', 'leviathan']
+          expect(drd.transitions.keys).to include("self", "update", "delete", "leviathan", "profile", "type", "help")
           
           status = drd.attributes['status']
           action = status == 'activated' ? 'deactivate' : 'activate'
@@ -99,7 +107,7 @@ describe Farscape::Representor do
           expect(deactivated_drd.attributes.keys).to eq(drd.attributes.keys)
           expect(deactivated_drd.transitions.keys).to_not eq(drd.transitions.keys)
           
-          # TODO: Make Moya error out when deactivating twice
+          # TODO: Make Moya error out when deactivating twice, change to something more straightforward
           # deactivate_transition.invoke # => raise Farscape::Agent::Gone error
         end
       end

--- a/spec/lib/farscape/integration/interface_spec.rb
+++ b/spec/lib/farscape/integration/interface_spec.rb
@@ -1,0 +1,130 @@
+require 'spec_helper'
+require 'json'
+
+describe Farscape::Representor do
+  let(:entry_point) { "http://localhost:#{RAILS_PORT}"}
+  
+  let(:drds_link) { Farscape::Agent.new(entry_point).enter.transitions["drds"] }
+  let(:can_do_hash) { {conditions: 'can_do_anything'} }
+  
+  describe "A Hypermedia API" do
+    it 'returns a Farscape::Representor instance 
+    with a simple state-machine interface of attributes (data) 
+    and transitions (link/form affordances) for interacting with the resource representations.' do
+      agent = Farscape::Agent.new(entry_point)
+      resources = agent.enter
+      expect(resources.attributes).to eq({})  # TODO: Add an attribute to the Moya entry point
+      expect(resources.transitions.keys).to eq(["drds"]) # => TODO: Add leviathans to Moya
+    end
+  end
+  
+  describe "A Hypermedia Discovery Service" do
+    # TODO: Fix Documentation to reflect this
+    
+    it 'follow your nose entry to select a registered resource' do
+      agent = Farscape::Agent.new(entry_point)
+      
+      resources = agent.enter
+      expect(resources.transitions['drds'].invoke).to be_a Farscape::Representor
+    end
+    
+    it 'immediately loading a discoverable resource if known to be registered in the service a priori.' do
+      agent = Farscape::Agent.new
+      
+      resources = agent.enter(entry_point)
+      expect(resources.transitions['drds'].invoke).to be_a Farscape::Representor
+    end
+    
+    it 'throws an error on an unknown resource' do
+      agent = Farscape::Agent.new
+      
+      expect{ agent.enter }.to raise_error(RuntimeError) # TODO: Create Exact Error Interface for Farscape
+    end
+  end
+  
+  context "API Interaction" do
+    
+    let(:agent) { Farscape::Agent.new(entry_point) }
+    let(:drds) { agent.enter.transitions['drds'].invoke { |req| req.parameters = can_do_hash } }
+    
+    describe "Load a Resource" do
+      it 'can load a resource' do
+        resources = agent.enter
+        drds_transition = resources.transitions['drds']
+        drds_resource = drds_transition.invoke { |req| req.parameters = can_do_hash } 
+        expect(drds_resource.transitions['self'].uri).to eq(drds.transitions['self'].uri)
+      end
+    end
+    
+    describe "Reload A Resource" do
+      it "can reload a resource" do
+        self_transition = drds.transitions['self']
+        reloaded_drds = self_transition.invoke
+        expect(reloaded_drds.to_hash).to eq(drds.to_hash)
+      end
+    end
+
+    context "Explore" do
+      describe "Apply Query Parameters" do
+        it 'allows Application of Query Parameters' do
+          search_transition = drds.transitions['search']
+          # Diverges from Doc do to doc not considering Field objects 
+          expect(search_transition.parameters.map { |p| p.name } ).to eq(['search_term','search_name'])
+          
+          filtered_drds = search_transition.invoke do |builder|
+            builder.parameters = { search_term: '1812' }
+          end
+          expect(filtered_drds.transitions['items']).to_not be(nil)
+        end
+      end
+
+      describe "Transform Resource State" do
+        it 'allows Transformation of Resource State' do
+          embedded_drd_items = drds.embedded # Orig "drds.items" Looks like New Interface
+          
+          drd = embedded_drd_items['items'].first
+          expect(drd.attributes.keys).to eq(['uuid','name','status','kind','leviathan_uuid','built_at'])
+          expect(drd.transitions.keys).to include("self", "update", "delete", "leviathan", "profile", "type", "help") # => ['self', 'edit', 'delete', 'deactivate', 'leviathan']
+          
+          status = drd.attributes['status']
+          action = status == 'activated' ? 'deactivate' : 'activate'
+          deactivate_transition = drd.transitions[action]
+           
+          # TODO: Not sure what to do about empty response bodies
+          # deactivated_drd = deactivate_transition.invoke 
+          deactivate_transition.invoke { |req| req.parameters = can_do_hash }
+          deactivated_drd = drd.transitions['self'].invoke { |req| req.parameters = can_do_hash }
+          
+          expect(deactivated_drd.attributes['status']).to_not eq(status)
+          expect(deactivated_drd.attributes.keys).to eq(drd.attributes.keys)
+          expect(deactivated_drd.transitions.keys).to_not eq(drd.transitions.keys)
+          
+          # TODO: Make Moya error out when deactivating twice
+          # deactivate_transition.invoke # => raise Farscape::Agent::Gone error
+        end
+      end
+
+      describe "Transform Application State" do
+        xit 'allows Transformation of Application State' do     
+# TODO: Make Moya serve Leviathan as a separate service
+#           leviathan_transition = deactivated_drd.transitions['leviathan']
+#           
+#           leviathan = leviathan_transition.invoke
+#           leviathan.attributes # => { name: 'Elack' }
+#           leviathan.transitions # => ['self', 'drds']
+#           
+#           # Use Attributes
+#           create_transition = drds.transitions['create']
+#           create_transition.attributes # => ['name']
+#           
+#           new_drd = create_transition.invoke do |builder|
+#             builder.attributes = { name: 'Pike' }
+#           end
+#           
+#           new_drd.attributes # => { name: 'Pike' }
+#           new_drd.transitions # => ['self', 'edit', 'delete', 'deactivate', 'leviathan']
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/farscape/integration/representor_spec.rb
+++ b/spec/lib/farscape/integration/representor_spec.rb
@@ -30,7 +30,7 @@ describe Farscape::Representor do
   describe '#attributes' do
     it 'has readable attributes' do
       representor = Farscape::Agent.new(entry_point).enter
-      expect(representor.transitions["drds"].invoke.attributes).to eq({"total_count"=>5})
+      expect(representor.transitions["drds"].invoke.attributes["total_count"]).to be > 4
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,14 +8,12 @@ $LOAD_PATH.uniq!
 
 require 'rspec'
 require 'pry'
-require 'debugger'
 require 'bundler'
 require 'simplecov'
 require 'faraday' #TODO move require for faraday into crichton test service
 require 'crichton_test_service'
 
 SimpleCov.start
-Debugger.start
 Bundler.setup
 
 require 'farscape'


### PR DESCRIPTION
This, to the best of my ability, ensures the interface as desgined in the documentation.
However there are several barriers to completely matching the documented interface.
1. Moya needs to be fleshed out more and support more.
2. Several documented use cases were inconsistent.
3. An Exact Error set and use cases need to be defined
4. The Interface does not consider field objects - see below.
5. Empty response bodies does not have well specified behavior
6. Moya needs to also serve a Leviathan service to show resource bridging

Regarding Fields:
The design called for

```
resource.attributes[field] # => 'field value'
```

This interface makes it impossible to discover important information about the field like it's scope, it's type, or its doc.

So instead you have to do

```
resource.attributes[field].value # => 'field value'
```

but this is ugly, this is why I proposed

```
resource.attributes[field] # => Representor::FieldObject
resource[field] # => field.value
```

Perhaps this is not the best interface, but the documented set doesn't cover all usecases.
