### PR TITLE
Farscape.cache the easy way

### DIFF
--- a/farscape.gemspec
+++ b/farscape.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'rake'
   s.add_dependency('addressable',   '~> 2.3.0')
   s.add_dependency('faraday',       '~> 0.8.8')
+  s.add_dependency('activesupport', '>= 0')
   s.add_development_dependency 'rspec'
 
 end

--- a/lib/farscape/cache.rb
+++ b/lib/farscape/cache.rb
@@ -1,0 +1,13 @@
+require 'active_support/cache'
+
+module Farscape
+
+  def self.cache
+    @cache ||= ActiveSupport::Cache::MemoryStore.new
+  end
+
+  def self.cache=(new_cache)
+    @cache = new_cache
+  end
+
+end

--- a/spec/lib/farscape/cache_spec.rb
+++ b/spec/lib/farscape/cache_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+require 'farscape/cache'
+
+describe(Farscape) do
+
+  describe 'cache' do
+
+    after(:each) { Farscape.cache = nil }
+
+    it 'defaults to a memory store' do
+      expect(Farscape.cache).to be_a(ActiveSupport::Cache::MemoryStore)
+    end
+
+    it 'does not require the full active_support suite' do
+      expect(Hash.new).not_to respond_to(:slice)
+    end
+
+    it 'can be set to any store' do
+      custom_cache = Object.new
+      Farscape.cache = custom_cache
+      expect(Farscape.cache).to eq(custom_cache)
+    end
+
+  end
+
+end


### PR DESCRIPTION
Starting on implementing the Farscape Utilities part of the plugin design. This fully implements `Farscape.cache`.
