### PR TITLE
Alternative Interface

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gem 'representors', git: 'https://www.github.com/mdsol-share/representors.git', 
 group :development, :test do
   gem 'pry'
   #TODO replace both crichton and crichton_test_service with references to stable branches when ready.
-  gem 'moya', git: 'https://www.github.com/mdsol/moya.git', branch: 'fix/active_uuid'
+  gem 'moya', git: 'https://www.github.com/mdsol/moya.git', branch: 'develop'
   gem 'crichton', git: 'https://www.github.com/mdsol-share/crichton.git', branch: 'develop'
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gem 'representors', git: 'https://www.github.com/mdsol-share/representors.git', 
 group :development, :test do
   gem 'pry'
   #TODO replace both crichton and crichton_test_service with references to stable branches when ready.
-  gem 'crichton_test_service', git: 'https://www.github.com/mdsol/moya.git', branch: 'develop'
+  gem 'moya', git: 'https://www.github.com/mdsol/moya.git', branch: 'fix/active_uuid'
   gem 'crichton', git: 'https://www.github.com/mdsol-share/crichton.git', branch: 'develop'
 end
 

--- a/lib/farscape/client/base_client.rb
+++ b/lib/farscape/client/base_client.rb
@@ -3,7 +3,7 @@ module Farscape
     # Client independent of protocol, only used for HTTP for now
     class BaseClient
 
-      def methods
+      def interface_methods
         {
           safe: [],
           unsafe: [],
@@ -11,16 +11,16 @@ module Farscape
         }
       end
 
-      def safe_methods
-        methods[:safe]
+      def safe_method?(meth)
+        interface_methods[:safe].include?(meth)
       end
 
-      def unsafe_methods
-        methods[:unsafe]
+      def unsafe_method?(meth)
+        interface_methods[:unsafe].include?(meth)
       end
 
-      def idempotent_methods
-        methods[:idempotent]
+      def idempotent_method?(meth)
+        interface_methods[:idempotent].include?(meth)
       end
     end
   end

--- a/lib/farscape/client/base_client.rb
+++ b/lib/farscape/client/base_client.rb
@@ -2,6 +2,26 @@ module Farscape
   class Agent
     # Client independent of protocol, only used for HTTP for now
     class BaseClient
+
+      def methods
+        {
+          safe: [],
+          unsafe: [],
+          idempotent: []
+        }
+      end
+
+      def safe_methods
+        methods[:safe]
+      end
+
+      def unsafe_methods
+        methods[:unsafe]
+      end
+
+      def idempotent_methods
+        methods[:idempotent]
+      end
     end
   end
 end

--- a/lib/farscape/client/http_client.rb
+++ b/lib/farscape/client/http_client.rb
@@ -33,6 +33,15 @@ module Farscape
           options[:headers].each { |k,v| req.headers[k] = v }
         end
       end
+
+      def methods
+        {
+          unsafe: ['PUT', 'DELETE'],
+          idempotent: ['POST', 'PATCH'], # http://tools.ietf.org/html/rfc5789
+          safe: ['GET', 'HEAD', 'OPTIONS', 'TRACE', 'CONNECT']
+        }
+      end
+
     end
   end
 end

--- a/lib/farscape/client/http_client.rb
+++ b/lib/farscape/client/http_client.rb
@@ -34,10 +34,10 @@ module Farscape
         end
       end
 
-      def methods
+      def interface_methods
         {
-          unsafe: ['PUT', 'DELETE'],
-          idempotent: ['POST', 'PATCH'], # http://tools.ietf.org/html/rfc5789
+          idempotent: ['PUT', 'DELETE'],
+          unsafe: ['POST', 'PATCH'], # http://tools.ietf.org/html/rfc5789
           safe: ['GET', 'HEAD', 'OPTIONS', 'TRACE', 'CONNECT']
         }
       end

--- a/lib/farscape/representor.rb
+++ b/lib/farscape/representor.rb
@@ -2,36 +2,80 @@ require 'representors'
 require 'farscape/transition'
 
 module Farscape
-  class Representor
+  class SafeRepresentorAgent
     attr_reader :agent
     attr_reader :representor
 
     # TODO: Work with Representor to make this straight forwqrd.
+    # The conditional is to allow direct creation of a RepresentorAgent from a Representor
     def initialize(requested_media_type, response_body, agent)
       @agent = agent
-      if requested_media_type
-        @representor = Representors::DeserializerFactory.build(requested_media_type, response_body).to_representor
-      else
-        @representor = response_body
-      end
+      @representor = requested_media_type ? deserialize(requested_media_type, response_body) : response_body
     end
 
     def attributes
       representor.properties
     end
 
+    #TODO: Handling list of transitions
     def transitions
-      Hash[representor.transitions.map{ |trans| [trans.rel, Farscape::Transition.new(trans, agent)]}]
+      Hash[representor.transitions.map{ |trans| [trans.rel, Farscape::TransitionAgent.new(trans, agent)] }]
     end
-    
+
     def embedded
-      Hash[representor.embedded.map do |k, reps| 
-           [k, reps.map { |rep| Representor.new(false, rep, agent) }]
-      end]
+      Hash[representor.embedded.map{ |k, reps| [k, reps.map { |rep| @agent.representor.new(false, rep, agent) }] }]
     end
 
     def to_hash
       @representor.to_hash
     end
+
+    def safe
+      reframe_representor(safe=true)
+    end
+
+    def unsafe
+      reframe_representor(safe=false)
+    end
+
+    private
+
+    def reframe_representor(safe)
+      agent = safe ? @agent.safe : @agent.unsafe
+      agent.representor.new(nil, @representor, agent)
+    end
+
+    def deserialize(requested_media_type, response_body)
+      Representors::DeserializerFactory.build(requested_media_type, response_body).to_representor
+    end
+
+  end
+
+  class RepresentorAgent < SafeRepresentorAgent
+    def method_missing(method, *args, &block)
+      method = method.to_s
+
+      get_embedded(method) || get_transition(method, *args, &block) || get_attribute(method) || raise(NoMethodError)
+    end
+
+    private
+
+    def get_embedded(method)
+      embedded[method]
+    end
+
+    def get_transition(method, *args, &block)
+      return false unless method_transitions.include?(method)
+      args.empty? ? method_transitions[method].invoke(&block) : method_transitions[method].invoke { |req| req.parameters = args.first }
+    end
+
+    def get_attribute(method)
+      attributes[method]
+    end
+
+    def method_transitions
+      transitions.map { |k,v| @agent.client.safe_methods.include?( v.interface_method ) ? {k => v}  : {k+'!' => v} }.reduce(:merge)
+    end
+
   end
 end

--- a/lib/farscape/transition.rb
+++ b/lib/farscape/transition.rb
@@ -11,9 +11,11 @@ module Farscape
       @transition = transition
     end
 
-    def invoke
+    def invoke(*args)
       options = OpenStruct.new
       yield options if block_given?
+
+      match_params(args)
 
       call_options = {}
       call_options[:url] = uri
@@ -26,9 +28,14 @@ module Farscape
       @agent.representor.new(@agent.media_type, response.body || EMPTY_BODIES[@agent.media_type], @agent)
     end
 
-    # TODO: Remove Constants from Representor Classes
     def method_missing(meth, *args, &block)
       @transition.send(meth, *args, &block)
+    end
+
+    def match_params(args)
+      print @transition
+      print "\np=", @transition.parameters
+      print "\na=", @transition.attributes
     end
   end
 end

--- a/lib/farscape/transition.rb
+++ b/lib/farscape/transition.rb
@@ -37,10 +37,15 @@ module Farscape
     def match_params(args, options)
       hash_filter = ->(hash,list) { hash.select { |k,_| list.include?(k) } }
       field_names = ->(field_list) { field_list.map { |field| field.name.to_sym } }
-      params = hash_filter.call(args, field_names.call(@transition.parameters))
-      attrs = hash_filter.call(args, field_names.call(@transition.attributes))
-      options.parameters = params.merge(options.parameters || {})
-      options.attributes = attrs.merge(options.attributes || {})
+            [:parameters, :attributes].each do |key_type|
+              filtered_values = hash_filter.call(args, field_names.call(@transition.public_send(key_type)))
+              options.public_send(:"#{key_type}=", filtered_values.merge(options.public_send(key_type) || {}))
+            end
+      # params = hash_filter.call(args, field_names.call(@transition.parameters))
+      # attrs = hash_filter.call(args, field_names.call(@transition.attributes))
+      # options.parameters = params.merge(options.parameters || {})
+      # options.attributes = attrs.merge(options.attributes || {})
+
       options
     end
   end

--- a/lib/farscape/transition.rb
+++ b/lib/farscape/transition.rb
@@ -35,18 +35,16 @@ module Farscape
     private
 
     def match_params(args, options)
-      hash_filter = ->(hash,list) { hash.select { |k,_| list.include?(k) } }
-      field_names = ->(field_list) { field_list.map { |field| field.name.to_sym } }
-            [:parameters, :attributes].each do |key_type|
-              filtered_values = hash_filter.call(args, field_names.call(@transition.public_send(key_type)))
-              options.public_send(:"#{key_type}=", filtered_values.merge(options.public_send(key_type) || {}))
-            end
-      # params = hash_filter.call(args, field_names.call(@transition.parameters))
-      # attrs = hash_filter.call(args, field_names.call(@transition.attributes))
-      # options.parameters = params.merge(options.parameters || {})
-      # options.attributes = attrs.merge(options.attributes || {})
-
+      [:parameters, :attributes].each do |key_type|
+        field_list = @transition.public_send(key_type)
+        field_names =field_list.map { |field| field.name.to_sym }
+        filtered_values = args.select { |k,_| field_names.include?(k) }
+        values = filtered_values.merge(options.public_send(key_type) || {})
+        options.public_send(:"#{key_type}=", values)
+      end
       options
     end
+
+
   end
 end

--- a/lib/farscape/transition.rb
+++ b/lib/farscape/transition.rb
@@ -2,7 +2,7 @@ require 'representors'
 require 'ostruct'
 
 module Farscape
-  class Transition
+  class TransitionAgent
 
     EMPTY_BODIES = { hale: "{}" } #TODO: Fix Representor to allow nil resources
 
@@ -23,9 +23,9 @@ module Farscape
       call_options[:body] = options.attributes if options.attributes
 
       response = @agent.client.invoke(call_options)
-      Representor.new(@agent.media_type, response.body || EMPTY_BODIES[@agent.media_type], @agent)
+      @agent.representor.new(@agent.media_type, response.body || EMPTY_BODIES[@agent.media_type], @agent)
     end
-    
+
     # TODO: Remove Constants from Representor Classes
     def method_missing(meth, *args, &block)
       @transition.send(meth, *args, &block)

--- a/spec/lib/farscape/cache_spec.rb
+++ b/spec/lib/farscape/cache_spec.rb
@@ -11,10 +11,6 @@ describe(Farscape) do
       expect(Farscape.cache).to be_a(ActiveSupport::Cache::MemoryStore)
     end
 
-    it 'does not require the full active_support suite' do
-      expect(Hash.new).not_to respond_to(:slice)
-    end
-
     it 'can be set to any store' do
       custom_cache = Object.new
       Farscape.cache = custom_cache

--- a/spec/lib/farscape/integration/entry_point_spec.rb
+++ b/spec/lib/farscape/integration/entry_point_spec.rb
@@ -5,11 +5,11 @@ describe Farscape::Agent do
 
   describe '#enter' do
     it 'returns a Farscape::Representor' do
-      expect(Farscape::Agent.new(entry_point).enter).to be_a Farscape::Representor
+      expect(Farscape::Agent.new(entry_point).enter).to be_a Farscape::RepresentorAgent
     end
 
     it 'can be provided an entry point after initialization' do
-      expect(Farscape::Agent.new.enter(entry_point)).to be_a Farscape::Representor
+      expect(Farscape::Agent.new.enter(entry_point)).to be_a Farscape::RepresentorAgent
     end
 
     #TODO decide on the appropriate error

--- a/spec/lib/farscape/integration/interface_spec.rb
+++ b/spec/lib/farscape/integration/interface_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'json'
 
-describe Farscape::RepresentorAgent do
+describe Farscape::SafeRepresentorAgent do
 
   # TODO: Make Representor::Field behave like a string
 
@@ -80,14 +80,16 @@ describe Farscape::RepresentorAgent do
         it "requires an ! on unsafe transitions" do
           agent = Farscape::Agent.new
           resources = agent.enter(entry_point)
-          expect { resources.drds(can_do_hash).create }.to raise_error(NoMethodError) # TODO: Create Exact Error Interface for Farscape
-          expect(resources.drds(can_do_hash).create!.transitions.keys).to include('self')
+          expect { resources.drds { |req| req.parameters = can_do_hash }.create }.to raise_error(NoMethodError) # TODO: Create Exact Error Interface for Farscape
+          expect(resources.drds { |req| req.parameters = can_do_hash }.create!.transitions.keys).to include('self')
         end
+
         it "can be called with arguments" do
           agent = Farscape::Agent.new
           resources = agent.enter(entry_point)
-          expect(resources.drds(can_do_hash).transitions.keys).to include('create')
+          expect(resources.drds.search(status: 'active').items.all? { |h| puts h }).to be true
         end
+
         it "can take a block" do
           agent = Farscape::Agent.new
           resources = agent.enter(entry_point)

--- a/spec/lib/farscape/integration/interface_spec.rb
+++ b/spec/lib/farscape/integration/interface_spec.rb
@@ -1,66 +1,66 @@
 require 'spec_helper'
 require 'json'
 
-describe Farscape::Representor do
-  
+describe Farscape::RepresentorAgent do
+
   # TODO: Make Representor::Field behave like a string
-  
+
   let(:entry_point) { "http://localhost:#{RAILS_PORT}"}
-  
+
   let(:drds_link) { Farscape::Agent.new(entry_point).enter.transitions["drds"] }
   let(:can_do_hash) { {conditions: 'can_do_anything'} }
-  
+
   describe "A Hypermedia API" do
-    it 'returns a Farscape::Representor instance 
-    with a simple state-machine interface of attributes (data) 
+    it 'returns a Farscape::Representor instance
+    with a simple state-machine interface of attributes (data)
     and transitions (link/form affordances) for interacting with the resource representations.' do
       agent = Farscape::Agent.new(entry_point)
       resources = agent.enter
-      
+
       expect(resources.attributes).to eq({})  # TODO: Make Crichton more flexible with Entry Points
       expect(resources.transitions.keys).to eq(["drds"]) # => TODO: Add leviathans to Moya
     end
   end
-  
+
   describe "A Hypermedia Discovery Service" do
     # TODO: Fix Documentation to reflect this
-    
+
     it 'follow your nose entry to select a registered resource' do
       agent = Farscape::Agent.new(entry_point)
       resources = agent.enter
-      
-      expect(resources.transitions['drds'].invoke).to be_a Farscape::Representor
+
+      expect(resources.transitions['drds'].invoke).to be_a Farscape::RepresentorAgent
     end
-    
+
     it 'immediately loading a discoverable resource if known to be registered in the service a priori.' do
       agent = Farscape::Agent.new
       resources = agent.enter(entry_point)
-      
-      expect(resources.transitions['drds'].invoke).to be_a Farscape::Representor
+
+      expect(resources.transitions['drds'].invoke).to be_a Farscape::RepresentorAgent
     end
-    
+
     it 'throws an error on an unknown resource' do
       agent = Farscape::Agent.new
-      
+
       expect{ agent.enter }.to raise_error(RuntimeError) # TODO: Create Exact Error Interface for Farscape
     end
   end
-  
+
   context "API Interaction" do
-    
+
     let(:agent) { Farscape::Agent.new(entry_point) }
     let(:drds) { agent.enter.transitions['drds'].invoke { |req| req.parameters = can_do_hash } }
-    
+
     describe "Load a Resource" do
       it 'can load a resource' do
         resources = agent.enter
         drds_transition = resources.transitions['drds']
-        drds_resource = drds_transition.invoke { |req| req.parameters = can_do_hash } 
+        drds_resource = drds_transition.invoke { |req| req.parameters = can_do_hash }
 
         expect(drds_resource.transitions['self'].uri).to eq(drds.transitions['self'].uri)
       end
     end
-    
+
     describe "Reload A Resource" do
       it "can reload a resource" do
         self_transition = drds.transitions['self']
@@ -70,14 +70,64 @@ describe Farscape::Representor do
       end
     end
 
+    describe "When using classmethods to refence API elements" do
+      context "When following unsafe transitions" do
+        it "can follow safe transitions" do
+          agent = Farscape::Agent.new
+          resources = agent.enter(entry_point)
+          expect(resources.drds).to be_a Farscape::RepresentorAgent
+        end
+        it "requires an ! on unsafe transitions" do
+          agent = Farscape::Agent.new
+          resources = agent.enter(entry_point)
+          expect { resources.drds(can_do_hash).create }.to raise_error(NoMethodError) # TODO: Create Exact Error Interface for Farscape
+          expect(resources.drds(can_do_hash).create!.transitions.keys).to include('self')
+        end
+        it "can be called with arguments" do
+          agent = Farscape::Agent.new
+          resources = agent.enter(entry_point)
+          expect(resources.drds(can_do_hash).transitions.keys).to include('create')
+        end
+        it "can take a block" do
+          agent = Farscape::Agent.new
+          resources = agent.enter(entry_point)
+          expect(resources.drds { |req| req.parameters = can_do_hash }.transitions.keys).to include('create')
+        end
+      end
+      context "When Referencing Attributes" do
+        it "can reference attributes" do
+          resource = agent.enter(entry_point).drds(can_do_hash).items.first
+          expect(resource.status).to eq(drds.embedded['items'].first.attributes['status'])
+        end
+        it "is read only" do
+          resource = agent.enter(entry_point).drds(can_do_hash).items.first
+          expect {resource.status = 'ninja food'}.to raise_error(NoMethodError)
+        end
+        it "throws on unknown" do
+          resource = agent.enter(entry_point).drds(can_do_hash).items.first
+          expect {resource.ninja}.to raise_error(NoMethodError)
+        end
+      end
+      context "When handling namespace collisions" do
+        it "can be converted to a safe representor and back" do
+          resource = agent.safe.enter.transitions['drds'].invoke { |req| req.parameters = can_do_hash }.embedded['items'].first
+          expect {resource.status}.to raise_error(NoMethodError)
+          resource = resource.unsafe
+          expect(resource.status).to eq(drds.embedded['items'].first.attributes['status'])
+          resource = resource.safe
+          expect {resource.status}.to raise_error(NoMethodError)
+        end
+      end
+    end
+
     context "Explore" do
       describe "Apply Query Parameters" do
         it 'allows Application of Query Parameters' do
           search_transition = drds.transitions['search']
 
-          # TODO: Diverges from Doc due to doc not considering Field objects 
+          # TODO: Diverges from Doc due to doc not considering Field objects
           expect(search_transition.parameters.map { |p| p.name } ).to eq(['search_term','search_name'])
-          
+
           filtered_drds = search_transition.invoke do |builder|
             builder.parameters = { search_term: '1812' } # TODO: Make Moya search like a normal person
           end
@@ -88,47 +138,47 @@ describe Farscape::Representor do
 
       describe "Transform Resource State" do
         it 'allows Transformation of Resource State' do
-          embedded_drd_items = drds.embedded # TODO: Orig "drds.items" Looks like New Interface          
+          embedded_drd_items = drds.embedded # TODO: Orig "drds.items" Looks like New Interface
           drd = embedded_drd_items['items'].first
 
           expect(drd.attributes.keys).to eq(['uuid','name','status','kind','leviathan_uuid','built_at'])
           expect(drd.transitions.keys).to include("self", "update", "delete", "leviathan", "profile", "type", "help")
-          
+
           status = drd.attributes['status']
           action = status == 'activated' ? 'deactivate' : 'activate'
           deactivate_transition = drd.transitions[action]
-           
+
           # TODO: Not sure what to do about empty response bodies
-          # deactivated_drd = deactivate_transition.invoke 
+          # deactivated_drd = deactivate_transition.invoke
           deactivate_transition.invoke { |req| req.parameters = can_do_hash }
           deactivated_drd = drd.transitions['self'].invoke { |req| req.parameters = can_do_hash }
-          
+
           expect(deactivated_drd.attributes['status']).to_not eq(status)
           expect(deactivated_drd.attributes.keys).to eq(drd.attributes.keys)
           expect(deactivated_drd.transitions.keys).to_not eq(drd.transitions.keys)
-          
+
           # TODO: Make Moya error out when deactivating twice, change to something more straightforward
           # deactivate_transition.invoke # => raise Farscape::Agent::Gone error
         end
       end
 
       describe "Transform Application State" do
-        xit 'allows Transformation of Application State' do     
+        xit 'allows Transformation of Application State' do
 # TODO: Make Moya serve Leviathan as a separate service
 #           leviathan_transition = deactivated_drd.transitions['leviathan']
-#           
+#
 #           leviathan = leviathan_transition.invoke
 #           leviathan.attributes # => { name: 'Elack' }
 #           leviathan.transitions # => ['self', 'drds']
-#           
+#
 #           # Use Attributes
 #           create_transition = drds.transitions['create']
 #           create_transition.attributes # => ['name']
-#           
+#
 #           new_drd = create_transition.invoke do |builder|
 #             builder.attributes = { name: 'Pike' }
 #           end
-#           
+#
 #           new_drd.attributes # => { name: 'Pike' }
 #           new_drd.transitions # => ['self', 'edit', 'delete', 'deactivate', 'leviathan']
         end

--- a/spec/lib/farscape/integration/representor_spec.rb
+++ b/spec/lib/farscape/integration/representor_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Farscape::Representor do
+describe Farscape::RepresentorAgent do
   let(:entry_point) { "http://localhost:#{RAILS_PORT}"}
 
   describe '#transitions' do
@@ -18,7 +18,7 @@ describe Farscape::Representor do
    describe "#invoke" do
       it 'returns a representor' do
         representor = Farscape::Agent.new(entry_point).enter
-         expect(representor.transitions["drds"].invoke).to be_a Farscape::Representor
+         expect(representor.transitions["drds"].invoke).to be_a Farscape::RepresentorAgent
       end
 
       it 'can reload a resource' do

--- a/spec/lib/farscape/integration/resource_crud_spec.rb
+++ b/spec/lib/farscape/integration/resource_crud_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'json'
 
-describe Farscape::Representor do
+describe Farscape::RepresentorAgent do
   let(:entry_point) { "http://localhost:#{RAILS_PORT}"}
 
   let(:drds_link) { Farscape::Agent.new(entry_point).enter.transitions["drds"] }
@@ -16,9 +16,9 @@ describe Farscape::Representor do
     it 'can create a drd' do
       name = 'Angry Max'
       drds_resource = drds_link.invoke { |req| req.parameters = can_do_hash }
-      drd = drds_resource.transitions['create'].invoke do |req| 
+      drd = drds_resource.transitions['create'].invoke do |req|
         req.attributes = {name: name}
-        req.parameters =  can_do_hash 
+        req.parameters =  can_do_hash
       end
       expect(drd.transitions['self'].invoke.attributes['name']).to eq(name)
       drd.transitions['delete'].invoke # Cleanup, failure here should imply failure in 'can delete a drd'
@@ -27,9 +27,9 @@ describe Farscape::Representor do
     context 'an existing drd' do
       before do
         drds_resource = drds_link.invoke { |req| req.parameters = can_do_hash }
-        @drd = drds_resource.transitions['create'].invoke do |req| 
+        @drd = drds_resource.transitions['create'].invoke do |req|
           req.attributes = params
-          req.parameters =  can_do_hash 
+          req.parameters =  can_do_hash
         end
       end
 
@@ -45,25 +45,25 @@ describe Farscape::Representor do
         error_attributes = @drd.transitions['self'].invoke { |r| r.parameters = can_do_hash }.to_hash[:attributes]
         expect(error_attributes).to_not eq(self_attributes)
       end
-      
+
       it 'can update a drd' do
         new_kind = "sentinel"
-        @drd.transitions['update'].invoke do |r| 
+        @drd.transitions['update'].invoke do |r|
           r.attributes = {kind: new_kind}
           r.parameters = can_do_hash
         end
         kindof = @drd.transitions['self'].invoke.attributes['kind']
         expect(kindof).to eq(new_kind)
       end
-      
+
       it 'can toggle a drds activation state' do
         status = @drd.attributes['status']
         action = status == 'activated' ? 'deactivate' : 'activate'
         @drd.transitions[action].invoke { |r| r.parameters = can_do_hash }
         new_status = @drd.transitions['self'].invoke { |r| r.parameters = can_do_hash }.attributes['status']
         expect(status).to_not eq(new_status)
-      end 
-      
+      end
+
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,7 +11,7 @@ require 'pry'
 require 'bundler'
 require 'simplecov'
 require 'faraday' #TODO move require for faraday into crichton test service
-require 'crichton_test_service'
+require 'moya'
 
 SimpleCov.start
 Bundler.setup
@@ -35,13 +35,13 @@ RSpec.configure do |config|
 
   config.before(:suite) do
     old_handler = trap(:INT) {
-      Process.kill(:INT, $crichton_test_rails_pid) if $crichton_test_rails_pid
+      Process.kill(:INT, $moya_rails_pid) if $moya_rails_pid
       old_handler.call if old_handler.respond_to?(:call)
     }
-    $crichton_test_rails_pid = CrichtonTestService.spawn_rails_process!(RAILS_PORT)
+    $moya_rails_pid = Moya.spawn_rails_process!(RAILS_PORT)
   end
 
   config.after(:suite) do
-    Process.kill(:INT, $crichton_test_rails_pid)
+    Process.kill(:INT, $moya_rails_pid)
   end
 end


### PR DESCRIPTION
This is getting safe and unsafe agents, where the unsafe agent has an Activerecordesque interface

added safe, unsafe, safe?, and representor methods to agent
extended base_client and http_client to include information about interface methods
renamed Representor to RepresentorAgent
created SafeRepresentorAgent which behaves like the old Representor
added interface to convert representor between these types
renames Transition to TransitionAgent
made TransitionAgent dispatch to the correct Representor type
Spec'd out interface
renamed Representor and Transition references to reflect naming convention
