### PR TITLE
[MCC-141788] Add missing faraday require

### DIFF
--- a/lib/farscape/client/http_client.rb
+++ b/lib/farscape/client/http_client.rb
@@ -1,4 +1,5 @@
 require 'farscape/client/base_client'
+require 'faraday'
 
 module Farscape
   class Agent

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,7 +10,6 @@ require 'rspec'
 require 'pry'
 require 'bundler'
 require 'simplecov'
-require 'faraday' #TODO move require for faraday into crichton test service
 require 'crichton_test_service'
 
 SimpleCov.start


### PR DESCRIPTION
We were missing a require in http_client.  This PR adds it, and removes a require in spec_helper that was masking the problem.

```
Finished in 39.68 seconds
56 examples, 0 failures, 1 pending
```
