### PR TITLE
Allow custom http client as per WRITING_PLUGINS

### DIFF
--- a/lib/farscape/agent.rb
+++ b/lib/farscape/agent.rb
@@ -1,5 +1,5 @@
 require 'farscape/representor'
-require 'farscape/client/http_client'
+require 'farscape/clients'
 
 module Farscape
   class Agent
@@ -27,7 +27,7 @@ module Farscape
     end
 
     def client
-      { http: HTTPClient }[PROTOCOL].new
+      Farscape.clients[PROTOCOL].new
     end
   end
 end

--- a/lib/farscape/client/http_client.rb
+++ b/lib/farscape/client/http_client.rb
@@ -24,8 +24,13 @@ module Farscape
             end
           end
           builder.request :url_encoded
-          builder.adapter Faraday.default_adapter
+          builder.adapter faraday_adapter
         end
+      end
+
+      # Override this in a subclass to create clients with custom Faraday adapters
+      def faraday_adapter
+        Faraday.default_adapter
       end
 
       ##

--- a/lib/farscape/clients.rb
+++ b/lib/farscape/clients.rb
@@ -1,0 +1,9 @@
+require 'farscape/client/http_client'
+
+module Farscape
+
+  def self.clients
+    @clients ||= {http: Farscape::Agent::HTTPClient}
+  end
+
+end


### PR DESCRIPTION
Does what WRITING_PLUGINS says we do, and makes it easy to create a custom HTTP client with a different Faraday adapter (e.g. net::http::persistent or EventMachine).
