### PR TITLE
Adds an accessible Response object to RepresentorAgent

### DIFF
--- a/lib/farscape/agent.rb
+++ b/lib/farscape/agent.rb
@@ -22,7 +22,7 @@ module Farscape
       @entry_point ||= entry
       raise "No Entry Point Provided!" unless entry
       response = client.invoke(url: entry, headers: get_accept_header(media_type))
-      representor.new(media_type, response.body, self)
+      representor.new(media_type, response, self)
     end
 
     # TODO share this information with serialization factory base

--- a/lib/farscape/transition.rb
+++ b/lib/farscape/transition.rb
@@ -5,8 +5,6 @@ module Farscape
 
   class TransitionAgent
 
-    EMPTY_BODIES = { hale: "{}" } #TODO: Fix Representor to allow nil resources
-
     def initialize(transition, agent)
       @agent = agent
       @transition = transition
@@ -25,7 +23,7 @@ module Farscape
       call_options[:body] = options.attributes if options.attributes
 
       response = @agent.client.invoke(call_options)
-      @agent.representor.new(@agent.media_type, response.body || EMPTY_BODIES[@agent.media_type], @agent)
+      @agent.representor.new(@agent.media_type, response, @agent)
     end
 
     def method_missing(meth, *args, &block)

--- a/spec/lib/farscape/integration/interface_spec.rb
+++ b/spec/lib/farscape/integration/interface_spec.rb
@@ -61,6 +61,14 @@ describe Farscape::SafeRepresentorAgent do
       end
     end
 
+    describe "A Representor Agent" do
+      it "Allows retrieving Response Header Information" do
+        resources = agent.enter
+        drds = resources.drds
+        expect(drds.response.status).to eq(200)
+      end
+    end
+
     describe "Reload A Resource" do
       it "can reload a resource" do
         self_transition = drds.transitions['self']


### PR DESCRIPTION
 While trying to get Dalton UI going, I noticed a glaring defect that Farscape had, specifically there was no way to get the actual request Response object.  This fixes that.

Changes:
Agent passes response and not just body to RepresentorAgent
Transitions pass response and not just body to RepresentorAgent
Moved nil body hack to RepresentorAgent
Added :response attr_reader
Refactored Embedded to emulate response
