### PR TITLE
Server Errors for Farscape

### DIFF
--- a/lib/farscape/client/http_client.rb
+++ b/lib/farscape/client/http_client.rb
@@ -1,6 +1,7 @@
 require 'faraday'
 require 'farscape/client/base_client'
 require 'farscape/plugins'
+require 'farscape/errors'
 
 module Farscape
   class Agent
@@ -62,6 +63,37 @@ module Farscape
           unsafe: ['POST', 'PATCH'], # http://tools.ietf.org/html/rfc5789
           safe: ['GET', 'HEAD', 'OPTIONS', 'TRACE', 'CONNECT']
         }
+      end
+
+      def dispatch_error(response)
+        errors = Farscape::Exceptions
+        http_code = {
+          400 => errors::BadRequest,
+          401 => errors::Unauthorized,
+          403 => errors::Forbidden,
+          404 => errors::NotFound,
+          405 => errors::MethodNotAllowed,
+          406 => errors::NotAcceptable,
+          407 => errors::ProxyAuthenticationRequired,
+          408 => errors::RequestTimeout,
+          409 => errors::Conflict,
+          410 => errors::Gone,
+          411 => errors::LengthRequired,
+          412 => errors::PreconditionFailed,
+          413 => errors::RequestEntityTooLarge,
+          414 => errors::RequestUriTooLong,
+          415 => errors::UnsupportedMediaType,
+          416 => errors::RequestedRangeNotSatisfiable,
+          417 => errors::ExpectationFailed,
+          418 => errors::ImaTeapot,
+          500 => errors::InternalServerError,
+          501 => errors::NotImplemented,
+          502 => errors::BadGateway,
+          503 => errors::ServiceUnavailable,
+          504 => errors::GatewayTimeout,
+          505 => errors::ProtocolVersionNotSupported,
+        }
+        return http_code[response.status]
       end
 
     end

--- a/lib/farscape/client/http_client.rb
+++ b/lib/farscape/client/http_client.rb
@@ -93,7 +93,7 @@ module Farscape
           504 => errors::GatewayTimeout,
           505 => errors::ProtocolVersionNotSupported,
         }
-        return http_code[response.status]
+        http_code[response.status]
       end
 
     end

--- a/lib/farscape/errors.rb
+++ b/lib/farscape/errors.rb
@@ -1,3 +1,5 @@
+require 'active_support/core_ext/string/filters'
+
 module Farscape
   module Exceptions
     class ProtocolException < IOError
@@ -26,20 +28,20 @@ module Farscape
         'The request requires user authentication.
         The client MAY repeat the request with suitable Authorization.
         If the request already included Authorization credentials,
-        then the response indicates that authorization has been refused for those credentials.'
+        then the response indicates that authorization has been refused for those credentials.'.squish
       end
     end
     class Forbidden < ProtocolException
       def error_description
         'The server understood the request, but is refusing to fulfill it.
-        Authorization will not help and the request SHOULD NOT be repeated.'
+        Authorization will not help and the request SHOULD NOT be repeated.'.squish
       end
     end
     class NotFound < ProtocolException
       def error_description
         'The server has not found anything matching the Request-URI.
         No indication is given of whether the condition is temporary or permanent.
-        This status code is commonly used when the server does not wish to reveal exactly why the request has been refused, or when no other response is applicable.'
+        This status code is commonly used when the server does not wish to reveal exactly why the request has been refused, or when no other response is applicable.'.squish
       end
     end
     class MethodNotAllowed < ProtocolException
@@ -55,13 +57,13 @@ module Farscape
     class ProxyAuthenticationRequired < ProtocolException
       def error_description
         'The client must first authenticate itself with the proxy.
-        The client MAY repeat the request with suitable Proxy Authorization.'
+        The client MAY repeat the request with suitable Proxy Authorization.'.squish
       end
     end
     class RequestTimeout < ProtocolException
       def error_description
         'The client did not produce a request within the time that the server was prepared to wait.
-        The client MAY repeat the request without modifications at any later time.'
+        The client MAY repeat the request without modifications at any later time.'.squish
       end
     end
     class Conflict < ProtocolException
@@ -69,7 +71,7 @@ module Farscape
         'The request could not be completed due to a conflict with the current state of the resource.
         This code is only allowed in situations where it is expected that the user might be able to resolve the conflict and resubmit the request.
         Conflicts are most likely to occur in response to an idempotent request.
-        For example, if versioning were being used and the entity included changes to a resource which conflict with those made by an earlier (third-party) request'
+        For example, if versioning were being used and the entity included changes to a resource which conflict with those made by an earlier (third-party) request'.squish
       end
     end
     class Gone < ProtocolException
@@ -77,7 +79,7 @@ module Farscape
         'The requested resource is no longer available at the server and no forwarding address is known.
         This condition is expected to be considered permanent.
         Clients with link editing capabilities SHOULD delete references to the Request-URI after user approval.
-        This response is cacheable unless indicated otherwise.'
+        This response is cacheable unless indicated otherwise.'.squish
       end
     end
     class LengthRequired < ProtocolException
@@ -92,7 +94,7 @@ module Farscape
     end
     class RequestEntityTooLarge < ProtocolException
       def error_description
-        'The server is refusing to process a request because the request entity is larger than the server is willing or able to process.'
+        'The server is refusing to process a request because the request entity is larger than the server is willing or able to process.'.squish
       end
     end
     class RequestUriTooLong < ProtocolException
@@ -109,19 +111,19 @@ module Farscape
       def error_description
         'A request requested a resource within a range,
         and none of the range-specifier values in this field overlap the current extent of the selected resource,
-        and the request did not specify range conditions.'
+        and the request did not specify range conditions.'.squish
       end
     end
     class ExpectationFailed < ProtocolException
       def error_description
         'The expectation given by the client could not be met by this server.
-        If the server is a proxy, the server has unambiguous evidence that the request could not be met by the next-hop server.'
+        If the server is a proxy, the server has unambiguous evidence that the request could not be met by the next-hop server.'.squish
       end
     end
     class ImaTeapot < ProtocolException
       def error_description
         'The server is a teapot; the resulting entity body may be short and stout.
-        Demonstrations of this behaviour exist.'
+        Demonstrations of this behaviour exist.'.squish
       end
     end
 
@@ -144,7 +146,7 @@ module Farscape
     class ServiceUnavailable < ProtocolException
       def error_description
         'The server is currently unable to handle the request due to a temporary overloading or maintenance of the server.
-        The implication is that this is a temporary condition which will be alleviated after some delay. '
+        The implication is that this is a temporary condition which will be alleviated after some delay.'.squish
       end
     end
     class GatewayTimeout < ProtocolException
@@ -155,7 +157,7 @@ module Farscape
     class ProtocolVersionNotSupported < ProtocolException
       def error_description
         'The server does not support, or refuses to support, the protocol or protocol version that was used in the request message.
-        The server is indicating that it is unable or unwilling to complete the request using the same protocol as the client'
+        The server is indicating that it is unable or unwilling to complete the request using the same protocol as the client'.squish
       end
     end
   end

--- a/lib/farscape/errors.rb
+++ b/lib/farscape/errors.rb
@@ -1,0 +1,162 @@
+module Farscape
+  module Exceptions
+    class ProtocolException < IOError
+      attr_reader :representor
+
+      def initialize(representor)
+        @representor = representor
+      end
+
+      def message
+        @representor.representor.to_hash
+      end
+
+      def error_description
+        'Unknown Error'
+      end
+    end
+    #4xx
+    class BadRequest < ProtocolException
+      def error_description
+        'The request could not be understood by the server due to malformed syntax. The client SHOULD NOT repeat the request without modifications.'
+      end
+    end
+    class Unauthorized < ProtocolException
+      def error_description
+        'The request requires user authentication.
+        The client MAY repeat the request with suitable Authorization.
+        If the request already included Authorization credentials,
+        then the response indicates that authorization has been refused for those credentials.'
+      end
+    end
+    class Forbidden < ProtocolException
+      def error_description
+        'The server understood the request, but is refusing to fulfill it.
+        Authorization will not help and the request SHOULD NOT be repeated.'
+      end
+    end
+    class NotFound < ProtocolException
+      def error_description
+        'The server has not found anything matching the Request-URI.
+        No indication is given of whether the condition is temporary or permanent.
+        This status code is commonly used when the server does not wish to reveal exactly why the request has been refused, or when no other response is applicable.'
+      end
+    end
+    class MethodNotAllowed < ProtocolException
+      def error_description
+        'The protocol method specified in the Request-Line is not allowed for the resource identified by the Request-URI.'
+      end
+    end
+    class NotAcceptable < ProtocolException
+      def error_description
+        'The resource identified by the request is only capable of generating response entities which have content characteristics not acceptable according to the accept headers sent in the request.'
+      end
+    end
+    class ProxyAuthenticationRequired < ProtocolException
+      def error_description
+        'The client must first authenticate itself with the proxy.
+        The client MAY repeat the request with suitable Proxy Authorization.'
+      end
+    end
+    class RequestTimeout < ProtocolException
+      def error_description
+        'The client did not produce a request within the time that the server was prepared to wait.
+        The client MAY repeat the request without modifications at any later time.'
+      end
+    end
+    class Conflict < ProtocolException
+      def error_description
+        'The request could not be completed due to a conflict with the current state of the resource.
+        This code is only allowed in situations where it is expected that the user might be able to resolve the conflict and resubmit the request.
+        Conflicts are most likely to occur in response to an idempotent request.
+        For example, if versioning were being used and the entity included changes to a resource which conflict with those made by an earlier (third-party) request'
+      end
+    end
+    class Gone < ProtocolException
+      def error_description
+        'The requested resource is no longer available at the server and no forwarding address is known.
+        This condition is expected to be considered permanent.
+        Clients with link editing capabilities SHOULD delete references to the Request-URI after user approval.
+        This response is cacheable unless indicated otherwise.'
+      end
+    end
+    class LengthRequired < ProtocolException
+      def error_description
+        'The server refuses to accept the request without a defined content length.'
+      end
+    end
+    class PreconditionFailed < ProtocolException
+      def error_description
+        'The precondition given by the client evaluated to false when it was tested on the server.'
+      end
+    end
+    class RequestEntityTooLarge < ProtocolException
+      def error_description
+        'The server is refusing to process a request because the request entity is larger than the server is willing or able to process.'
+      end
+    end
+    class RequestUriTooLong < ProtocolException
+      def error_description
+        'The server is refusing to service the request because the Request-URI is longer than the server is willing to interpret.'
+        end
+    end
+    class UnsupportedMediaType < ProtocolException
+      def error_description
+        'The server is refusing to service the request because the entity of the request is in a format not supported by the requested resource for the requested method.'
+      end
+    end
+    class RequestedRangeNotSatisfiable < ProtocolException
+      def error_description
+        'A request requested a resource within a range,
+        and none of the range-specifier values in this field overlap the current extent of the selected resource,
+        and the request did not specify range conditions.'
+      end
+    end
+    class ExpectationFailed < ProtocolException
+      def error_description
+        'The expectation given by the client could not be met by this server.
+        If the server is a proxy, the server has unambiguous evidence that the request could not be met by the next-hop server.'
+      end
+    end
+    class ImaTeapot < ProtocolException
+      def error_description
+        'The server is a teapot; the resulting entity body may be short and stout.
+        Demonstrations of this behaviour exist.'
+      end
+    end
+
+    #5xx
+    class InternalServerError < ProtocolException
+      def error_description
+        'The server encountered an unexpected condition which prevented it from fulfilling the request.'
+      end
+    end
+    class NotImplemented < ProtocolException
+      def error_description
+        'The server does not support the functionality required to fulfill the request.'
+      end
+    end
+    class BadGateway < ProtocolException
+      def error_description
+        'The server received an invalid response from the upstream server it accessed in attempting to fulfill the request.'
+      end
+    end
+    class ServiceUnavailable < ProtocolException
+      def error_description
+        'The server is currently unable to handle the request due to a temporary overloading or maintenance of the server.
+        The implication is that this is a temporary condition which will be alleviated after some delay. '
+      end
+    end
+    class GatewayTimeout < ProtocolException
+      def error_description
+        'The server did not receive a timely response from an upstream server specified it needed to access in attempting to complete the request.'
+      end
+    end
+    class ProtocolVersionNotSupported < ProtocolException
+      def error_description
+        'The server does not support, or refuses to support, the protocol or protocol version that was used in the request message.
+        The server is indicating that it is unable or unwilling to complete the request using the same protocol as the client'
+      end
+    end
+  end
+end

--- a/lib/farscape/transition.rb
+++ b/lib/farscape/transition.rb
@@ -24,9 +24,7 @@ module Farscape
 
       response = @agent.client.invoke(call_options)
 
-      find_exception(response) #Guard the Return
-
-      reagent(response)
+      find_exception(response) || reagent(response)
     end
 
     def method_missing(meth, *args, &block)

--- a/lib/farscape/transition.rb
+++ b/lib/farscape/transition.rb
@@ -23,7 +23,10 @@ module Farscape
       call_options[:body] = options.attributes if options.attributes
 
       response = @agent.client.invoke(call_options)
-      @agent.representor.new(@agent.media_type, response, @agent)
+
+      find_exception(response) #Guard the Return
+
+      reagent(response)
     end
 
     def method_missing(meth, *args, &block)
@@ -31,6 +34,15 @@ module Farscape
     end
 
     private
+
+    def reagent(response)
+      @agent.representor.new(@agent.media_type, response, @agent)
+    end
+
+    def find_exception(response)
+      error = @agent.client.dispatch_error(response)
+      raise error.new(reagent(response)) unless error.nil?
+    end
 
     def match_params(args, options)
       [:parameters, :attributes].each do |key_type|

--- a/spec/lib/farscape/integration/resource_crud_spec.rb
+++ b/spec/lib/farscape/integration/resource_crud_spec.rb
@@ -47,7 +47,7 @@ describe Farscape::RepresentorAgent do
         expect { recall_drds.call }.to raise_error( Farscape::Exceptions::NotFound )
       end
 
-      it 'can returns proper errors' do
+      it 'returns proper errors' do
         # NB We compare attributes as the self link will differ between the two calls
         recall_drds = ->() { @drd.transitions['self'].invoke { |r| r.parameters = can_do_hash }.to_hash[:attributes] }
         drd_attributes = @drd.to_hash[:attributes]

--- a/spec/lib/farscape/integration/resource_crud_spec.rb
+++ b/spec/lib/farscape/integration/resource_crud_spec.rb
@@ -55,7 +55,6 @@ describe Farscape::RepresentorAgent do
         begin
           recall_drds.call
         rescue Farscape::Exceptions::NotFound => e
-          p e
           expect(e.error_description).to eq(Farscape::Exceptions::NotFound.new(nil).error_description)
           expect(e.representor.to_hash).to eq(e.message)
         end

--- a/spec/lib/farscape/integration/resource_crud_spec.rb
+++ b/spec/lib/farscape/integration/resource_crud_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 require 'json'
+require 'active_support/core_ext/string/filters'
 
 describe Farscape::RepresentorAgent do
   let(:entry_point) { "http://localhost:#{RAILS_PORT}"}
@@ -56,7 +57,9 @@ describe Farscape::RepresentorAgent do
           recall_drds.call
           raise Exception.new('Moya responded with a resource that\'s been deleted')
         rescue Farscape::Exceptions::NotFound => e
-          expect(e.error_description).to eq(Farscape::Exceptions::NotFound.new(nil).error_description)
+          expect(e.error_description).to eq('The server has not found anything matching the Request-URI.
+          No indication is given of whether the condition is temporary or permanent.
+          This status code is commonly used when the server does not wish to reveal exactly why the request has been refused, or when no other response is applicable.'.squish)
           expect(e.representor.to_hash).to eq(e.message)
         end
       end

--- a/spec/lib/farscape/integration/resource_crud_spec.rb
+++ b/spec/lib/farscape/integration/resource_crud_spec.rb
@@ -54,6 +54,7 @@ describe Farscape::RepresentorAgent do
         @drd.transitions['delete'].invoke
         begin
           recall_drds.call
+          raise Exception.new('Moya responded with a resource that\'s been deleted')
         rescue Farscape::Exceptions::NotFound => e
           expect(e.error_description).to eq(Farscape::Exceptions::NotFound.new(nil).error_description)
           expect(e.representor.to_hash).to eq(e.message)


### PR DESCRIPTION
This adds Server Errors for farcape

Added Server Errors
Made Error descriptions
Dispatch to Errors in transitions
Dispatch to errors in HTTP Protocol
representor accessible (and thus response accessible) from error
Future Plans:
  Add other Client Errors (e.g. unknown transition)
  Add .maybe method to representor to try transition without raising
