### PR TITLE
Toggling Between Safe and Unsafe 

### DIFF
--- a/lib/farscape/representor.rb
+++ b/lib/farscape/representor.rb
@@ -45,8 +45,6 @@ module Farscape
     private
 
     def reframe_representor(safety)
-      #require 'pry'
-      #binding.pry
       agent = safety ? @agent.safe : @agent.unsafe
       agent.representor.new(@requested_media_type, @response, agent)
     end

--- a/lib/farscape/representor.rb
+++ b/lib/farscape/representor.rb
@@ -13,6 +13,7 @@ module Farscape
     def initialize(requested_media_type, response, agent)
       @agent = agent
       @response = response
+      @requested_media_type = requested_media_type
       @representor = deserialize(requested_media_type, response.body)
     end
 
@@ -43,9 +44,11 @@ module Farscape
 
     private
 
-    def reframe_representor(safe)
-      agent = safe ? @agent.safe : @agent.unsafe
-      agent.representor.new(nil, @response, agent)
+    def reframe_representor(safety)
+      #require 'pry'
+      #binding.pry
+      agent = safety ? @agent.safe : @agent.unsafe
+      agent.representor.new(@requested_media_type, @response, agent)
     end
 
     def deserialize(requested_media_type, response_body)

--- a/spec/lib/farscape/integration/interface_spec.rb
+++ b/spec/lib/farscape/integration/interface_spec.rb
@@ -136,6 +136,16 @@ describe Farscape::SafeRepresentorAgent do
           expect {resource.status}.to raise_error(NoMethodError)
         end
       end
+
+      context "When using ALternate Interface" do
+        it "can change to and from a safe representor" do
+           drds = agent.enter(entry_point).drds(can_do_hash)
+           safely = drds.safe
+           unsafely = safely.unsafe
+           expect(safely.transitions.keys).to eq(unsafely.transitions.keys) # TODO: Representor should support descriptor equality
+        end
+      end
+
     end
 
     context "Explore" do

--- a/spec/lib/farscape/integration/interface_spec.rb
+++ b/spec/lib/farscape/integration/interface_spec.rb
@@ -137,7 +137,7 @@ describe Farscape::SafeRepresentorAgent do
         end
       end
 
-      context "When using ALternate Interface" do
+      context "When using Alternate Interface" do
         it "can change to and from a safe representor" do
            drds = agent.enter(entry_point).drds(can_do_hash)
            safely = drds.safe

--- a/spec/lib/farscape/integration/interface_spec.rb
+++ b/spec/lib/farscape/integration/interface_spec.rb
@@ -142,7 +142,9 @@ describe Farscape::SafeRepresentorAgent do
            drds = agent.enter(entry_point).drds(can_do_hash)
            safely = drds.safe
            unsafely = safely.unsafe
+           expect(safely.attributes.keys).to eq(unsafely.attributes.keys) # TODO: Representor should support descriptor equality
            expect(safely.transitions.keys).to eq(unsafely.transitions.keys) # TODO: Representor should support descriptor equality
+           expect(safely.embedded.keys).to eq(unsafely.embedded.keys) # TODO: Representor should support descriptor equality
         end
       end
 


### PR DESCRIPTION
It was returning a string instead of a Representor.  This fixes that by passing in the media type for redeserialization.
