### PR TITLE
Fix Proper No Method Error on Unknown Transitions under certain conditions.

### DIFF
--- a/lib/farscape/representor.rb
+++ b/lib/farscape/representor.rb
@@ -94,7 +94,7 @@ module Farscape
     end
 
     def method_transitions
-      transitions.map { |k,v| @agent.client.safe_method?( v.interface_method ) ? {k => v}  : {k+'!' => v} }.reduce(:merge) || {}
+      transitions.map { |k,v| @agent.client.safe_method?( v.interface_method ) ? {k => v}  : {k+'!' => v} }.reduce({}, :merge)
     end
 
   end

--- a/lib/farscape/representor.rb
+++ b/lib/farscape/representor.rb
@@ -94,7 +94,7 @@ module Farscape
     end
 
     def method_transitions
-      transitions.map { |k,v| @agent.client.safe_method?( v.interface_method ) ? {k => v}  : {k+'!' => v} }.reduce(:merge)
+      transitions.map { |k,v| @agent.client.safe_method?( v.interface_method ) ? {k => v}  : {k+'!' => v} }.reduce(:merge) || {}
     end
 
   end

--- a/spec/lib/farscape/integration/interface_spec.rb
+++ b/spec/lib/farscape/integration/interface_spec.rb
@@ -44,6 +44,9 @@ describe Farscape::SafeRepresentorAgent do
 
       expect{ agent.enter }.to raise_error(RuntimeError) # TODO: Create Exact Error Interface for Farscape
     end
+
+    it 'raises a NoMethodError '
+
   end
 
   context "API Interaction" do
@@ -120,8 +123,9 @@ describe Farscape::SafeRepresentorAgent do
           expect {resource.status = 'ninja food'}.to raise_error(NoMethodError)
         end
         it "throws on unknown" do
-          resource = agent.enter(entry_point).drds(can_do_hash).items.first
+          resource = agent.enter(entry_point).drds(can_do_hash).items.select { |drd| drd.status == 'deactivated' }.first
           expect {resource.ninja}.to raise_error(NoMethodError)
+          expect {resource.self {|r| r.parameters = {'conditions' => 'can_do_anything'}}.activate!.activate!}.to raise_error(NoMethodError, /undefined method `activate!' for.*/)
         end
       end
       context "When handling namespace collisions" do

--- a/spec/lib/farscape/integration/interface_spec.rb
+++ b/spec/lib/farscape/integration/interface_spec.rb
@@ -121,9 +121,9 @@ describe Farscape::SafeRepresentorAgent do
           expect {resource.status = 'ninja food'}.to raise_error(NoMethodError)
         end
         it "throws on unknown" do
-          resource = agent.enter(entry_point).drds(can_do_hash).items.select { |drd| drd.status == 'deactivated' }.first
+          resource = agent.enter(entry_point).drds(can_do_hash).items.find { |drd| drd.status == 'deactivated' }
           expect {resource.ninja}.to raise_error(NoMethodError)
-          expect {resource.self {|r| r.parameters = {'conditions' => 'can_do_anything'}}.activate!.activate!}.to raise_error(NoMethodError, /undefined method `activate!' for.*/)
+          expect {resource.self {|r| r.parameters = {'conditions' => 'can_do_anything'}}.activate!.activate!}.to raise_error(NoMethodError, /undefined method `activate!' for/)
         end
       end
       context "When handling namespace collisions" do

--- a/spec/lib/farscape/integration/interface_spec.rb
+++ b/spec/lib/farscape/integration/interface_spec.rb
@@ -45,8 +45,6 @@ describe Farscape::SafeRepresentorAgent do
       expect{ agent.enter }.to raise_error(RuntimeError) # TODO: Create Exact Error Interface for Farscape
     end
 
-    it 'raises a NoMethodError '
-
   end
 
   context "API Interaction" do


### PR DESCRIPTION
Certain conditions caused a NoMethodError: undefined method `include?' for nil:NilClass when dispatching through 'method transitions' in RepresentorAgent.

This replicates that condition and supplies the fix whereby an empty has is returned instead of nil.
