### PR TITLE
Farscape can't send empty bodies.

### DIFF
--- a/lib/farscape/client/http_client.rb
+++ b/lib/farscape/client/http_client.rb
@@ -12,6 +12,7 @@ module Farscape
 
       def initialize
         @connection = Faraday.new do |builder|
+          builder.request :url_encoded
           Farscape.middleware_stack.each do |middleware|
             if middleware.key?(:config)
               config = middleware[:config]
@@ -24,7 +25,7 @@ module Farscape
               builder.use(middleware[:class])
             end
           end
-          builder.request :url_encoded
+
           builder.adapter faraday_adapter
         end
       end
@@ -41,19 +42,14 @@ module Farscape
       #  params, body, and headers.
       # @return [Faraday::Response] The response object resulting from the Faraday call
       def invoke(options = {})
-        defaults = { url:     '',
-                     method:  'get',
-                     params:  {},
-                     body:    '',
-                     headers: {}
-                    }
+        defaults = { method:  'get'}
         options = defaults.merge(options)
 
         connection.send(options[:method].to_s.downcase) do |req|
           req.url options[:url]
-          req.body = options[:body]
-          options[:params].each { |k,v| req.params[k] = v }
-          options[:headers].each { |k,v| req.headers[k] = v }
+          req.body = options[:body] if options.has_key?(:body)
+          options[:params].each { |k,v| req.params[k] = v } if options.has_key?(:params)
+          options[:headers].each { |k,v| req.headers[k] = v } if options.has_key?(:headers)
         end
       end
 

--- a/lib/farscape/transition.rb
+++ b/lib/farscape/transition.rb
@@ -11,16 +11,22 @@ module Farscape
     end
 
     def invoke(args={})
+      defaults = { url:     '',
+                   method:  'get',
+                   params:  {},
+                   body:    '', #WRONG!
+                   headers: {} #WRONG!
+                  }
       opts=OpenStruct.new
       yield opts if block_given?
       options = match_params(args, opts)
 
       call_options = {}
-      call_options[:url] = @transition.uri
-      call_options[:method] = @transition.interface_method
+      call_options[:url] = @transition.uri || ''
+      call_options[:method] = @transition.interface_method || 'get'
       call_options[:headers] = @agent.get_accept_header(@agent.media_type).merge(options.headers || {})
-      call_options[:params] = options.parameters if options.parameters
-      call_options[:body] = options.attributes if options.attributes
+      call_options[:params] = options.parameters ? options.parameters : {}
+      call_options[:body] = options.attributes ? options.attributes : ''
 
       response = @agent.client.invoke(call_options)
 

--- a/lib/farscape/transition.rb
+++ b/lib/farscape/transition.rb
@@ -18,11 +18,11 @@ module Farscape
       # binding.pry
 
       call_options = {}
-      call_options[:url] = @transition.uri || ''
-      call_options[:method] = @transition.interface_method || 'get'
+      call_options[:url] = @transition.uri
+      call_options[:method] = @transition.interface_method
       call_options[:headers] = @agent.get_accept_header(@agent.media_type).merge(options.headers || {})
-      call_options[:params] = options.parameters || {}
-      call_options[:body] = options.attributes.empty? ? '' : options.attributes
+      call_options[:params] = options.parameters unless options.parameters.blank?
+      call_options[:body] = options.attributes unless options.parameters.blank?
 
       response = @agent.client.invoke(call_options)
 

--- a/lib/farscape/transition.rb
+++ b/lib/farscape/transition.rb
@@ -14,13 +14,15 @@ module Farscape
       opts=OpenStruct.new
       yield opts if block_given?
       options = match_params(args, opts)
+      # require 'pry'
+      # binding.pry
 
       call_options = {}
       call_options[:url] = @transition.uri || ''
       call_options[:method] = @transition.interface_method || 'get'
       call_options[:headers] = @agent.get_accept_header(@agent.media_type).merge(options.headers || {})
       call_options[:params] = options.parameters || {}
-      call_options[:body] = options.attributes || ''
+      call_options[:body] = options.attributes.empty? ? '' : options.attributes
 
       response = @agent.client.invoke(call_options)
 

--- a/lib/farscape/transition.rb
+++ b/lib/farscape/transition.rb
@@ -11,12 +11,6 @@ module Farscape
     end
 
     def invoke(args={})
-      defaults = { url:     '',
-                   method:  'get',
-                   params:  {},
-                   body:    '', #WRONG!
-                   headers: {} #WRONG!
-                  }
       opts=OpenStruct.new
       yield opts if block_given?
       options = match_params(args, opts)

--- a/lib/farscape/transition.rb
+++ b/lib/farscape/transition.rb
@@ -19,8 +19,8 @@ module Farscape
       call_options[:url] = @transition.uri || ''
       call_options[:method] = @transition.interface_method || 'get'
       call_options[:headers] = @agent.get_accept_header(@agent.media_type).merge(options.headers || {})
-      call_options[:params] = options.parameters ? options.parameters : {}
-      call_options[:body] = options.attributes ? options.attributes : ''
+      call_options[:params] = options.parameters || {}
+      call_options[:body] = options.attributes || ''
 
       response = @agent.client.invoke(call_options)
 

--- a/lib/farscape/transition.rb
+++ b/lib/farscape/transition.rb
@@ -14,8 +14,6 @@ module Farscape
       opts=OpenStruct.new
       yield opts if block_given?
       options = match_params(args, opts)
-      # require 'pry'
-      # binding.pry
 
       call_options = {}
       call_options[:url] = @transition.uri


### PR DESCRIPTION
It seems sensible to send an empty request body when you have no data in your request.  However mauth seems to require that the body /exist/ even when it's empty.  This fix forces farscape to always have a request body even when it's empty.

(This might be considered a bug in mauth)
