### PR TITLE
Fix Attributes Bug

### DIFF
--- a/lib/farscape/transition.rb
+++ b/lib/farscape/transition.rb
@@ -20,7 +20,7 @@ module Farscape
       call_options[:method] = @transition.interface_method
       call_options[:headers] = @agent.get_accept_header(@agent.media_type).merge(options.headers || {})
       call_options[:params] = options.parameters unless options.parameters.blank?
-      call_options[:body] = options.attributes unless options.parameters.blank?
+      call_options[:body] = options.attributes unless options.attributes.blank?
 
       response = @agent.client.invoke(call_options)
 


### PR DESCRIPTION
A bug was introduced in the last PR.  Attributes weren't getting set unless parameters were also set.
Currently there is no way to test this in moya, because there are no queries that can have a body that don't also require a 'conditions' parameter.
