### PR TITLE
Minor change to fix bug

### DIFF
--- a/lib/farscape/plugins.rb
+++ b/lib/farscape/plugins.rb
@@ -34,7 +34,7 @@ module Farscape
     # Else if :default_state was passed in return :default_state
     def why_disabled(options)
       maybe = @disabling_rules.map { |hash| hash.select { |k,v| k if v == options[k] } }
-      maybe |= [disabled_plugins[:name]]
+      maybe |= [disabled_plugins[options[:name]]]
       maybe |= [:default_state] if options[:default_state] == :disabled
       maybe.compact
     end

--- a/lib/farscape/plugins.rb
+++ b/lib/farscape/plugins.rb
@@ -34,9 +34,9 @@ module Farscape
     # Else if :default_state was passed in return :default_state
     def why_disabled(options)
       maybe = @disabling_rules.map { |hash| hash.select { |k,v| k if v == options[k] } }
-      maybe |= disabled_plugins.map { |k,v| v[:name] }
+      maybe |= [disabled_plugins[:name]]
       maybe |= [:default_state] if options[:default_state] == :disabled
-      maybe
+      maybe.compact
     end
     
     def disabled?(options)

--- a/spec/lib/farscape/plugins_spec.rb
+++ b/spec/lib/farscape/plugins_spec.rb
@@ -152,6 +152,18 @@ describe Farscape do
         expect(Farscape.enabled_plugins.keys).to eq([:Saboteur])
       end
 
+      it 'doesn\'t allow sneaky enabling' do
+        detector_plugin = {name: :Detector, type: :sebacean, middleware: [TestMiddleware::SabotageDetector], default_state: :disabled}
+        Farscape.register_plugin(detector_plugin)
+        
+        expect(Farscape.disabled_plugins.keys).to eq([:Detector])
+        
+        detector_plugin = {name: :Detector, type: :sebacean, middleware: [TestMiddleware::SabotageDetector], default_state: :enabled}
+        Farscape.register_plugin(detector_plugin)
+        
+        expect(Farscape.disabled_plugins.keys).to eq([:Detector])
+      end
+
     end
 
     context 'workflow' do

--- a/spec/lib/farscape/plugins_spec.rb
+++ b/spec/lib/farscape/plugins_spec.rb
@@ -121,8 +121,8 @@ describe Farscape do
       [:sebacean, TestMiddleware::SabotageDetector,'TestMiddleware::SabotageDetector',['TestMiddleware::SabotageDetector']].each do |form|
         it "honors the before: option in middleware when given as #{form.inspect}" do
           saboteur_middleware = {class: TestMiddleware::Saboteur, before: form}
-          saboteur_plugin = {name: :saboteur, type: :scarran, middleware: [saboteur_middleware]}
-          detector_plugin = {name: :detector, type: :sebacean, middleware: [TestMiddleware::SabotageDetector]}
+          saboteur_plugin = {name: :Saboteur, type: :scarran, middleware: [saboteur_middleware]}
+          detector_plugin = {name: :Detector, type: :sebacean, middleware: [TestMiddleware::SabotageDetector]}
           [saboteur_plugin, detector_plugin].shuffle.each { |plugin| Farscape.register_plugin(plugin) }
           
           expect(Farscape.middleware_stack.map{ |m| m[:class] }).to eq( [TestMiddleware::Saboteur, TestMiddleware::SabotageDetector] )
@@ -133,8 +133,8 @@ describe Farscape do
       [:sebacean, TestMiddleware::SabotageDetector,'TestMiddleware::SabotageDetector',['TestMiddleware::SabotageDetector']].each do |form|
         it "honors the after: option in middleware when given as #{form.inspect}" do
           saboteur_middleware = {class: TestMiddleware::Saboteur, after: form}
-          saboteur_plugin = {name: :saboteur, type: :scarran, middleware: [saboteur_middleware]}
-          detector_plugin = {name: :detector, type: :sebacean, middleware: [TestMiddleware::SabotageDetector]}
+          saboteur_plugin = {name: :Saboteur, type: :scarran, middleware: [saboteur_middleware]}
+          detector_plugin = {name: :Detector, type: :sebacean, middleware: [TestMiddleware::SabotageDetector]}
           [saboteur_plugin, detector_plugin].shuffle.each { |plugin| Farscape.register_plugin(plugin) }
           
           expect(Farscape.middleware_stack.map{ |m| m[:class] }).to eq( [TestMiddleware::SabotageDetector, TestMiddleware::Saboteur] )
@@ -143,13 +143,13 @@ describe Farscape do
       end
       
       it 'doesn\'t disable everything with one' do
-        detector_plugin = {name: :detector, type: :sebacean, middleware: [TestMiddleware::SabotageDetector], default_state: :disabled}
+        detector_plugin = {name: :Detector, type: :sebacean, middleware: [TestMiddleware::SabotageDetector], default_state: :disabled}
         saboteur_middleware = {class: TestMiddleware::Saboteur}
-        saboteur_plugin = {name: :saboteur, type: :scarran, middleware: [saboteur_middleware]}
+        saboteur_plugin = {name: :Saboteur, type: :scarran, middleware: [saboteur_middleware]}
         Farscape.register_plugin(detector_plugin)
         Farscape.register_plugin(saboteur_plugin)
         
-        expect(Farscape.enabled_plugins.keys).to eq([:saboteur])
+        expect(Farscape.enabled_plugins.keys).to eq([:Saboteur])
       end
 
     end


### PR DESCRIPTION
The first disabled plugin was disabling all other plugins that registered afterward, because why_disabled's second assertion was just that there existed a disabled plugin and it had a name.
