### PR TITLE
Agent#using and plugin restructure

### DIFF
--- a/lib/farscape.rb
+++ b/lib/farscape.rb
@@ -1,1 +1,2 @@
+require 'plugins/plugins'
 require 'farscape/agent'

--- a/lib/farscape/agent.rb
+++ b/lib/farscape/agent.rb
@@ -8,11 +8,11 @@ module Farscape
     attr_reader :media_type
     attr_reader :entry_point
     
-    def initialize(entry = nil, media = :hale, safe = false, pluginhash = {})
+    def initialize(entry = nil, media = :hale, safe = false, plugin_hash = {})
       @entry_point = entry
       @media_type = media
       @safe_mode = safe
-      @pluginhash = pluginhash.empty? ? default_plugin_hash : pluginhash
+      @plugin_hash = plugin_hash.empty? ? default_plugin_hash : plugin_hash
     end
 
     def representor
@@ -48,11 +48,11 @@ module Farscape
     end
 
     def safe
-      self.class.new(@entry_point, @media_type, true, @pluginhash)
+      self.class.new(@entry_point, @media_type, true, @plugin_hash)
     end
 
     def unsafe
-      self.class.new(@entry_point, @media_type, false, @pluginhash)
+      self.class.new(@entry_point, @media_type, false, @plugin_hash)
     end
 
     def safe?
@@ -60,15 +60,15 @@ module Farscape
     end
 
     def enabled_plugins
-      Plugins.enabled_plugins(@pluginhash[:plugins])
+      Plugins.enabled_plugins(@plugin_hash[:plugins])
     end
 
     def middleware_stack
-      @pluginhash[:middleware_stack] ||= Plugins.construct_stack(enabled_plugins)
+      @plugin_hash[:middleware_stack] ||= Plugins.construct_stack(enabled_plugins)
     end
 
     def using(name_or_type)
-      disabling_rules, plugins = Plugins.enable(name_or_type, @pluginhash[:disabling_rules], @pluginhash[:plugins])
+      disabling_rules, plugins = Plugins.enable(name_or_type, @plugin_hash[:disabling_rules], @plugin_hash[:plugins])
       plugin_hash = {
         disabling_rules: disabling_rules,
         plugins: plugins,

--- a/lib/farscape/agent.rb
+++ b/lib/farscape/agent.rb
@@ -81,11 +81,11 @@ module Farscape
     
     def default_plugin_hash
       {
-        plugins: Farscape.plugins.dup,
-        disabling_rules: Farscape.disabling_rules.dup,
+        plugins: Farscape.plugins.dup,  # A hash of plugins keyed by the plugin name
+        disabling_rules: Farscape.disabling_rules.dup, # A list of symbols that are Names or types of plugins
         middleware_stack: nil
       }
     end
-    
+
   end
 end

--- a/lib/farscape/client/http_client.rb
+++ b/lib/farscape/client/http_client.rb
@@ -9,11 +9,12 @@ module Farscape
 
       # The Faraday connection instance.
       attr_reader :connection
+      attr_reader :Plugins
 
-      def initialize
+      def initialize(agent)
         @connection = Faraday.new do |builder|
           builder.request :url_encoded
-          Farscape.middleware_stack.each do |middleware|
+          agent.middleware_stack.each do |middleware|
             if middleware.key?(:config)
               config = middleware[:config]
               if config.is_a?(Array)

--- a/lib/farscape/plugins.rb
+++ b/lib/farscape/plugins.rb
@@ -7,8 +7,8 @@ module Farscape
     attr_reader :plugins
     attr_reader :disabling_rules
 
-    @plugins = {}
-    @disabling_rules = []
+    @plugins = {} # A hash of plugins keyed by the plugin name
+    @disabling_rules = [] # A list of symbols that are Names or types of plugins
     @middleware_stack = nil
     
     def self.plugins

--- a/lib/farscape/plugins.rb
+++ b/lib/farscape/plugins.rb
@@ -1,132 +1,71 @@
 require_relative 'helpers/partially_ordered_list'
 
 module Farscape
-
-  @plugins = {}
-  @disabling_rules = []
-  @_middleware_stack = nil
-
-  class <<self
+  
+    extend Plugins
 
     attr_reader :plugins
     attr_reader :disabling_rules
 
-    def register_plugin(options)
+    @plugins = {}
+    @disabling_rules = []
+    @middleware_stack = nil
+    
+    def self.plugins
+      @plugins
+    end
+
+    def self.disabling_rules
+      @disabling_rules
+    end
+      
+    def self.register_plugin(options)
       @middleware_stack = nil
-      options[:enabled] = enabled?(options)
+      options[:enabled] = self.enabled?(options)
       @plugins[options[:name]] = options
     end
 
-    def register_plugins(a_list)
+    def self.register_plugins(a_list)
       a_list.each { |options| register_plugin(options) }
     end
 
-    def enabled_plugins
-      @plugins.select { |plugin| @plugins[plugin][:enabled] }
+    # Returns the Poset representing middleware dependency
+    def self.middleware_stack
+      @middleware_stack ||= Plugins.construct_stack(enabled_plugins)
     end
 
-    def disabled_plugins
-      @plugins.reject { |plugin| @plugins[plugin][:enabled] }
+    def self.enabled_plugins
+      Plugins.enabled_plugins(@plugins)
     end
 
-    # If the middleware has been disabled by name, return the name
-    # Else if by type, return the type.
-    # Else if :default_state was passed in return :default_state
-    def why_disabled(options)
-      maybe = @disabling_rules.map { |hash| hash.select { |k,v| k if v == options[k] } }
-      maybe |= [disabled_plugins[options[:name]]]
-      maybe |= [:default_state] if options[:default_state] == :disabled
-      maybe.compact
+    def self.disabled_plugins
+      Plugins.disabled_plugins(@plugins)
     end
     
-    def disabled?(options)
-      options = normalize_selector(options)
-      return @plugins[options[:name]][:enabled] if options.include?([:name])
-      why_disabled(options).any?
+    def self.disabled?(options)
+      Plugins.disabled?(@plugins, @disabling_rules, options)
     end
     
-    def enabled?(options)
-      !disabled?(options)
+    def self.enabled?(options)
+      Plugins.enabled?(@plugins, @disabling_rules, options)
     end
 
     # Prevents a plugin from being registered, and disables it if it's already there
-    def disable!(name_or_type)
+    def self.disable!(name_or_type)
       @middleware_stack = nil
-      name_or_type = normalize_selector(name_or_type)
-      @disabling_rules << name_or_type
-      set_plugin_states(name_or_type, false)
+      @disabling_rules, @plugins = Plugins.disable(name_or_type, @disabling_rules, @plugins)
     end
 
     # Allows a plugin to be registered, and enables it if it's already there
-    def enable!(name_or_type)
+    def self.enable!(name_or_type)
       @middleware_stack = nil
-      name_or_type = normalize_selector(name_or_type)
-      @disabling_rules.delete(name_or_type)
-      set_plugin_states(name_or_type, true)
-    end
-
-    # Returns the Poset representing middleware dependency
-    def middleware_stack
-      @middleware_stack ||= construct_stack(enabled_plugins)
+      @disabling_rules, @plugins = Plugins.enable(name_or_type, @disabling_rules, @plugins)
     end
     
     # Removes all plugins and disablings of plugins
-    def clear
+    def self.clear
       @plugins = {}
       @disabling_rules = []
       @middleware_stack = nil
     end
-
-    private
-
-    def set_plugin_states(name_or_type, condition)
-      selected_plugins = find_attr_intersect(@plugins, name_or_type)
-      selected_plugins.each { |plugin| @plugins[plugin][:enabled] = condition }
-    end
-
-    def construct_stack(plugins)
-      stack = PartiallyOrderedList.new { |m,n| order_middleware(m,n) }
-      plugins.each do |_, plugin|
-        [*plugin[:middleware]].each do |middleware|
-          middleware = {class: middleware} unless middleware.is_a?(Hash)
-          middleware[:type] = plugin[:type]
-          middleware[:plugin] = plugin[:name]
-          stack.add(middleware)
-        end
-      end
-      stack
-    end
-
-    def normalize_selector(name_or_type)
-      name_or_type.is_a?(Hash) ? name_or_type : { name: name_or_type, type: name_or_type}
-    end
-
-    # Used by PartiallyOrderedList to implement the before: and after: options
-    def order_middleware(mw_1, mw_2)
-      case
-      when includes_middleware?(mw_1[:before],mw_2)
-        -1
-      when includes_middleware?(mw_1[:after],mw_2)
-        1
-      when includes_middleware?(mw_2[:before],mw_1)
-        1
-      when includes_middleware?(mw_2[:after],mw_1)
-        -1
-      end
-    end
-
-    def find_attr_intersect(master_hash, selector_hash)
-      master_hash.map do |mkey, mval|
-        selector_hash.map { |skey, sval| mkey if mval[skey] == sval }
-      end.flatten.compact
-    end
-
-    # Search a list for a given middleware by either its class or the type of its originating plugin
-    def includes_middleware?(list, middleware)
-      list = [*list]
-      list.map(&:to_s).include?(middleware[:class].to_s) || list.include?(middleware[:type])
-    end
-
-  end
-
 end

--- a/lib/plugins/plugins.rb
+++ b/lib/plugins/plugins.rb
@@ -1,0 +1,95 @@
+module Farscape
+  module Plugins
+
+    def self.enabled_plugins(plugins)
+      plugins.select { |plugin| plugins[plugin][:enabled] }
+    end
+
+    def self.disabled_plugins(plugins)
+      plugins.reject { |plugin| plugins[plugin][:enabled] }
+    end
+
+    # If the middleware has been disabled by name, return the name
+    # Else if by type, return the type.
+    # Else if :default_state was passed in return :default_state
+    def self.why_disabled(plugins, disabling_rules, options)
+      maybe = disabling_rules.map { |hash| hash.select { |k,v| k if v == options[k] } }
+      maybe |= [disabled_plugins(plugins)[options[:name]]]
+      maybe |= [:default_state] if options[:default_state] == :disabled
+      maybe.compact
+    end
+    
+    def self.disabled?(plugins, disabling_rules, options)
+      options = normalize_selector(options)
+      return plugins[options[:name]][:enabled] if options.include?([:name])
+      why_disabled(plugins, disabling_rules, options).any?
+    end
+    
+    def self.enabled?(plugins, disabling_rules, options)
+      !self.disabled?(plugins, disabling_rules, options)
+    end
+
+    def self.disable(name_or_type, disabling_rules, plugins)
+      name_or_type = self.normalize_selector(name_or_type)
+      plugins = set_plugin_states(name_or_type, false, plugins)
+      [disabling_rules << name_or_type, plugins]      
+    end
+
+    def self.enable(name_or_type, disabling_rules, plugins)
+      name_or_type = normalize_selector(name_or_type)
+      plugins = set_plugin_states(name_or_type, true, plugins)
+      [disabling_rules.reject {|k| k == name_or_type}, plugins]      
+    end
+
+    def self.set_plugin_states(name_or_type, condition, plugins)
+      plugins = Marshal.load( Marshal.dump(plugins) ) # TODO: This is super inefficient, figure out a good deep_dup
+      selected_plugins = find_attr_intersect(plugins, name_or_type)
+      selected_plugins.each { |plugin| plugins[plugin][:enabled] = condition }
+      plugins
+    end
+
+    def self.construct_stack(plugins)
+      stack = PartiallyOrderedList.new { |m,n| order_middleware(m,n) }
+      plugins.each do |_, plugin|
+        [*plugin[:middleware]].each do |middleware|
+          middleware = {class: middleware} unless middleware.is_a?(Hash)
+          middleware[:type] = plugin[:type]
+          middleware[:plugin] = plugin[:name]
+          stack.add(middleware)
+        end
+      end
+      stack
+    end
+
+    def self.normalize_selector(name_or_type)
+      name_or_type.is_a?(Hash) ? name_or_type : { name: name_or_type, type: name_or_type}
+    end
+
+    # Used by PartiallyOrderedList to implement the before: and after: options
+    def self.order_middleware(mw_1, mw_2)
+      case
+      when includes_middleware?(mw_1[:before],mw_2)
+        -1
+      when includes_middleware?(mw_1[:after],mw_2)
+        1
+      when includes_middleware?(mw_2[:before],mw_1)
+        1
+      when includes_middleware?(mw_2[:after],mw_1)
+        -1
+      end
+    end
+
+    def self.find_attr_intersect(master_hash, selector_hash)
+      master_hash.map do |mkey, mval|
+        selector_hash.map { |skey, sval| mkey if mval[skey] == sval }
+      end.flatten.compact
+    end
+
+    # Search a list for a given middleware by either its class or the type of its originating plugin
+    def self.includes_middleware?(list, middleware)
+      list = [*list]
+      list.map(&:to_s).include?(middleware[:class].to_s) || list.include?(middleware[:type])
+    end
+
+  end
+end

--- a/spec/lib/farscape/plugins_spec.rb
+++ b/spec/lib/farscape/plugins_spec.rb
@@ -37,6 +37,25 @@ module TestMiddleware
 
 end
 
+describe Farscape::Agent do
+  before(:each) { Farscape.clear }
+  after(:all) { Farscape.clear }
+  
+  let(:entry_point) { "http://localhost:#{RAILS_PORT}"}
+  
+  it 'acc' do
+    detector_plugin = {name: :Detector, type: :sebacean, middleware: [TestMiddleware::SabotageDetector], default_state: :disabled}
+    saboteur_middleware = {class: TestMiddleware::Saboteur, before: :sebacean}
+    saboteur_plugin = {name: :Saboteur, type: :scarran, middleware: [saboteur_middleware]}
+    Farscape.register_plugin(detector_plugin)
+    Farscape.register_plugin(saboteur_plugin)
+    
+    expect { Farscape::Agent.new(entry_point).using(:Detector).enter }.to raise_error('Sabotage detected')
+  end
+  
+end
+
+
 describe Farscape do
   after(:all) { Farscape.clear }  
   

--- a/spec/lib/farscape/plugins_spec.rb
+++ b/spec/lib/farscape/plugins_spec.rb
@@ -43,7 +43,7 @@ describe Farscape::Agent do
   
   let(:entry_point) { "http://localhost:#{RAILS_PORT}"}
   
-  it 'acc' do
+  it 'accepts a using directive that enables plugins' do
     detector_plugin = {name: :Detector, type: :sebacean, middleware: [TestMiddleware::SabotageDetector], default_state: :disabled}
     saboteur_middleware = {class: TestMiddleware::Saboteur, before: :sebacean}
     saboteur_plugin = {name: :Saboteur, type: :scarran, middleware: [saboteur_middleware]}
@@ -51,6 +51,18 @@ describe Farscape::Agent do
     Farscape.register_plugin(saboteur_plugin)
     
     expect { Farscape::Agent.new(entry_point).using(:Detector).enter }.to raise_error('Sabotage detected')
+  end
+
+  it 'using does not modify Farscape' do
+    detector_plugin = {name: :Detector, type: :sebacean, middleware: [TestMiddleware::SabotageDetector], default_state: :disabled}
+    saboteur_middleware = {class: TestMiddleware::Saboteur, before: :sebacean}
+    saboteur_plugin = {name: :Saboteur, type: :scarran, middleware: [saboteur_middleware]}
+    Farscape.register_plugin(detector_plugin)
+    Farscape.register_plugin(saboteur_plugin)
+    
+    agent = Farscape::Agent.new(entry_point).using(:Detector)
+    expect(agent.enabled_plugins[:Detector]).to_not be_nil
+    expect(Farscape.disabled_plugins[:Detector]).to_not be_nil
   end
   
 end


### PR DESCRIPTION
This restructures the plugin functionality such that the logic is separated entirely from all state changes.  This allows Agent to have its own separate opinion about plugins than the Farscaped environment does.

Changes:
Test for Agent#using
Added plugins/plugins.rb to hold the plugins logic
Changed farscape/plugins.rb to center around Farscape state changes
Changed agent to have its own plugin logic
Changed http_client to point at agents middleware stack
