### PR TITLE
Adds Extensions functionality to Farscape Plugins

### DIFF
--- a/lib/farscape.rb
+++ b/lib/farscape.rb
@@ -1,2 +1,3 @@
 require 'plugins/plugins'
+require 'farscape/base_agent'
 require 'farscape/agent'

--- a/lib/farscape/agent.rb
+++ b/lib/farscape/agent.rb
@@ -3,6 +3,9 @@ require 'farscape/clients'
 
 module Farscape
   class Agent
+    
+    include BaseAgent
+    
     PROTOCOL = :http
 
     attr_reader :media_type
@@ -14,12 +17,6 @@ module Farscape
       @safe_mode = safe
       @plugin_hash = plugin_hash.empty? ? default_plugin_hash : plugin_hash
       handle_extensions
-    end
-
-    def handle_extensions
-      extensions = Plugins.extensions(enabled_plugins)
-      extensions = extensions[self.class.to_s.split(':')[-1].to_sym]
-      extensions.map { |cls| self.extend(cls) } if extensions
     end
 
     def representor

--- a/lib/farscape/agent.rb
+++ b/lib/farscape/agent.rb
@@ -13,6 +13,13 @@ module Farscape
       @media_type = media
       @safe_mode = safe
       @plugin_hash = plugin_hash.empty? ? default_plugin_hash : plugin_hash
+      handle_extensions
+    end
+
+    def handle_extensions
+      extensions = Plugins.extensions(enabled_plugins)
+      extensions = extensions[self.class.to_s.split(':')[-1].to_sym]
+      extensions.map { |cls| self.extend(cls) } if extensions
     end
 
     def representor

--- a/lib/farscape/base_agent.rb
+++ b/lib/farscape/base_agent.rb
@@ -1,0 +1,15 @@
+module Farscape
+  module BaseAgent
+    
+    def handle_extensions
+      extensions = Plugins.extensions(enabled_plugins)
+      extensions = extensions[self.class.to_s.split(':')[-1].to_sym]
+      extensions.each { |cls| self.extend(cls) } if extensions
+    end
+
+    %w(disabled_plugins enabled_plugins plugins).each do |meth|
+      define_method(meth) { @agent.send(meth) }
+    end
+    
+  end
+end

--- a/lib/farscape/representor.rb
+++ b/lib/farscape/representor.rb
@@ -15,6 +15,13 @@ module Farscape
       @response = response
       @requested_media_type = requested_media_type
       @representor = deserialize(requested_media_type, response.body)
+      handle_extensions
+    end
+
+    def handle_extensions
+      extensions = Plugins.extensions(enabled_plugins)
+      extensions = extensions[self.class.to_s.split(':')[-1].to_sym]
+      extensions.map { |cls| self.extend(cls) } if extensions
     end
     
     %w(using omitting).each do |meth|

--- a/lib/farscape/representor.rb
+++ b/lib/farscape/representor.rb
@@ -4,6 +4,9 @@ require 'ostruct'
 
 module Farscape
   class SafeRepresentorAgent
+    
+    include BaseAgent
+    
     attr_reader :agent
     attr_reader :representor
     attr_reader :response
@@ -17,19 +20,9 @@ module Farscape
       @representor = deserialize(requested_media_type, response.body)
       handle_extensions
     end
-
-    def handle_extensions
-      extensions = Plugins.extensions(enabled_plugins)
-      extensions = extensions[self.class.to_s.split(':')[-1].to_sym]
-      extensions.map { |cls| self.extend(cls) } if extensions
-    end
     
     %w(using omitting).each do |meth|
       define_method(meth) { |name_or_type| self.class.new(@requested_media_type, @response, @agent.send(meth, name_or_type)) }
-    end
-
-    %w(disabled_plugins enabled_plugins plugins).each do |meth|
-      define_method(meth) { @agent.send(meth) }
     end
 
     def attributes

--- a/lib/farscape/transition.rb
+++ b/lib/farscape/transition.rb
@@ -6,6 +6,8 @@ module Farscape
 
   class TransitionAgent
 
+    include BaseAgent
+
     def initialize(transition, agent)
       @agent = agent
       @transition = transition
@@ -29,20 +31,9 @@ module Farscape
       @agent.find_exception(response)
     end
 
-    def handle_extensions
-      extensions = Plugins.extensions(enabled_plugins)
-      extensions = extensions[self.class.to_s.split(':')[-1].to_sym]
-      extensions.map { |cls| self.extend(cls) } if extensions
-    end
-
     %w(using omitting).each do |meth|
       define_method(meth) { |name_or_type| self.class.new(@transition, @agent.send(meth, name_or_type)) }
     end
-
-    %w(disabled_plugins enabled_plugins plugins).each do |meth|
-      define_method(meth) { @agent.send(meth) }
-    end
-
 
     def method_missing(meth, *args, &block)
       @transition.send(meth, *args, &block)

--- a/lib/farscape/transition.rb
+++ b/lib/farscape/transition.rb
@@ -9,6 +9,7 @@ module Farscape
     def initialize(transition, agent)
       @agent = agent
       @transition = transition
+      handle_extensions
     end
 
     def invoke(args={})
@@ -26,6 +27,12 @@ module Farscape
       response = @agent.client.invoke(call_options)
 
       @agent.find_exception(response)
+    end
+
+    def handle_extensions
+      extensions = Plugins.extensions(enabled_plugins)
+      extensions = extensions[self.class.to_s.split(':')[-1].to_sym]
+      extensions.map { |cls| self.extend(cls) } if extensions
     end
 
     %w(using omitting).each do |meth|

--- a/lib/plugins/plugins.rb
+++ b/lib/plugins/plugins.rb
@@ -91,5 +91,14 @@ module Farscape
       list.map(&:to_s).include?(middleware[:class].to_s) || list.include?(middleware[:type])
     end
 
+    def self.extensions(plugins)
+      plugs = plugins.map { |_, hash| hash[:extensions] }.compact
+      collect_values(plugs)
+    end
+
+    def self.collect_values(hashes)
+      hashes.reduce({}) { |h1, h2| h1.merge(h2) { |k, l1, l2| l1+l2 } }
+    end
+
   end
 end

--- a/spec/lib/farscape/plugins_spec.rb
+++ b/spec/lib/farscape/plugins_spec.rb
@@ -234,7 +234,7 @@ describe Farscape do
       it 'allows extensions' do
         module Peacekeeper
           def pacify!
-            raise 'none shall pass' if enabled_plugins.include?(:Peacekeeper)
+            raise 'none shall pass' unless enabled_plugins.include?(:Saboteur)
           end
         end
         Farscape.register_plugin(name: :Peacekeeper, type: :security, extensions: {Agent: [Peacekeeper]})

--- a/spec/lib/farscape/plugins_spec.rb
+++ b/spec/lib/farscape/plugins_spec.rb
@@ -242,7 +242,7 @@ describe Farscape do
       end
       
       it 'allows extensions with altering existing methods' do
-        module Peacekeeper
+        module Peacemaker
           def self.extended(base)
             base.instance_eval do
               @original_transitions = method(:transitions)
@@ -253,7 +253,7 @@ describe Farscape do
             end
           end
         end
-        Farscape.register_plugin(name: :Peacekeeper, type: :security, extensions: {RepresentorAgent: [Peacekeeper]})
+        Farscape.register_plugin(name: :Peacekeeper, type: :security, extensions: {RepresentorAgent: [Peacemaker]})
         expect { Farscape::Agent.new.enter(entry_point).transitions.keys }.to raise_error('none shall pass')
         expect(Farscape::Agent.new.enter(entry_point).omitting(:Peacekeeper).transitions.keys).to include("drds")
       end

--- a/spec/lib/farscape/plugins_spec.rb
+++ b/spec/lib/farscape/plugins_spec.rb
@@ -258,7 +258,7 @@ describe Farscape do
         expect(Farscape::Agent.new.enter(entry_point).omitting(:Peacekeeper).transitions.keys).to include("drds")
       end
       
-      it 'allows deiscovery extensions' do
+      it 'allows discovery extensions' do
         module ServiceCatalogue
           def self.extended(base)
             base.instance_eval do


### PR DESCRIPTION
This adds the ability to modify Agent, RepresentorAgent, and TransitionAgent in Farscaope.

Changes:
 added handle_extensions in Agent, RepresentorAgent, and TransitionAgent
 added extensions method to Plugins
 tests for simple Extensions and modified existing methods
