### PR TITLE
Feature/redirecting

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem 'rake',          '~> 0.9'
 gem 'awesome_print', '~> 1.1.0'
 gem 'redcarpet'
 
-gem 'representors', git: 'https://www.github.com/mdsol-share/representors.git', branch: '0-0-stable'
+gem 'representors', git: 'git@github.com:mdsol/representors.git', branch: '0-0-stable'
 
 group :development, :test do
   gem 'pry'

--- a/farscape.gemspec
+++ b/farscape.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'rake'
   s.add_dependency('addressable',   '~> 2.3.0')
   s.add_dependency('faraday',       '~> 0.8.8')
+  s.add_dependency('faraday_middleware',       '~> 0.9')
   s.add_dependency('activesupport', '>= 0')
 
   s.add_development_dependency 'rspec'

--- a/lib/farscape/agent.rb
+++ b/lib/farscape/agent.rb
@@ -27,7 +27,7 @@ module Farscape
       @entry_point ||= entry
       raise "No Entry Point Provided!" unless entry
       response = client.invoke(url: entry, headers: get_accept_header(media_type))
-      find_exception(response)
+      find_exception(response, entry_point)
     end
 
     def find_exception(response, entry_point='')

--- a/lib/farscape/agent.rb
+++ b/lib/farscape/agent.rb
@@ -30,11 +30,12 @@ module Farscape
       find_exception(response)
     end
 
-    def find_exception(response)
+    def find_exception(response, entry_point='')
       error = client.dispatch_error(response)
       begin
         representing = representor.new(media_type, response, self)
       rescue JSON::ParserError
+        Rails.logger.error("Farscape could not parse the response #{response} when accessing #{entry_point}")
         representing = response
       end
       raise error.new(representing) if error

--- a/lib/farscape/client/http_client.rb
+++ b/lib/farscape/client/http_client.rb
@@ -2,6 +2,7 @@ require 'faraday'
 require 'farscape/client/base_client'
 require 'farscape/plugins'
 require 'farscape/errors'
+require 'faraday_middleware'
 
 module Farscape
   class Agent
@@ -14,6 +15,9 @@ module Farscape
       def initialize(agent)
         @connection = Faraday.new do |builder|
           builder.request :url_encoded
+
+          builder.use FaradayMiddleware::FollowRedirects
+
           agent.middleware_stack.each do |middleware|
             if middleware.key?(:config)
               config = middleware[:config]

--- a/lib/farscape/errors.rb
+++ b/lib/farscape/errors.rb
@@ -10,7 +10,13 @@ module Farscape
       end
 
       def message
-        @representor.representor.to_hash
+        if @representor.respond_to?(:representor)
+          @representor.representor.to_hash
+        elsif @representor.respond_to?(:body) #Farscape will happily return a Faraday Response when it can not be parsed
+          @representor.body
+        else
+          "Unknown object #{@representor.class} retrieved as a representor: >>#{@representor.inspect}<<"
+        end
       end
 
       def error_description

--- a/lib/farscape/transition.rb
+++ b/lib/farscape/transition.rb
@@ -20,7 +20,7 @@ module Farscape
       options = match_params(args, opts)
 
       call_options = {}
-      call_options[:url] = @transition.uri
+      call_options[:url] = @transition.uri(options.parameters)
       call_options[:method] = @transition.interface_method
       call_options[:headers] = @agent.get_accept_header(@agent.media_type).merge(options.headers || {})
       call_options[:params] = options.parameters unless options.parameters.blank?

--- a/spec/lib/farscape/client/http_client_spec.rb
+++ b/spec/lib/farscape/client/http_client_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+describe Farscape::Agent::HTTPClient do
+
+  describe 'initializer' do
+    it 'uses redirect middlware' do
+      agent = double('an agent')
+      allow(agent).to receive(:middleware_stack).and_return([])
+      client = Farscape::Agent::HTTPClient.new(agent)
+      expect(client.connection.builder.handlers.any?{|handler| handler.name == 'FaradayMiddleware::FollowRedirects'}).to eq(true)
+    end
+  end
+
+end


### PR DESCRIPTION
@HonoreDB  @miwest929 

PR for you to take a look at but probably not to be merged immediately.
This is not passing the CI because it references the private representors which can not be pulled by Travis.
I think probably the private representors should be synced to the public and delete the private to make it clear which one is the repo. Then maybe move this to mdsol-share.

For Angelfire we need the changes in this PR. I probably would open two pull requests for them, one let us use the templates and the other adds the FollowRedirect middleware which we need as we find the 302 when calling Gambit.
Farscape without this middleware was giving us UnknownProtocol error.

For Angelfire R1, we are using a github reference so this is not urgent for us. I vote for coming back to this and do the above  (move repos, etc) after these critical days are gone.
I am opening this as a PR now to keep you informed and to see if we are doing something horribly wrong here.
