### PR TITLE
Update Faraday dependency to ~> 0.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,9 @@
 language: ruby
-rvm:
-  - 1.9.3
-  - 2.0.0
-  - 2.1.1
-gemfile:
-- Gemfile
 cache: bundler
+sudo: false
+
+rvm:
+  - 2.1.8
+  - 2.2.4
+  - 2.3.0
 script: "bundle exec rspec"
-before_install:
-  - sudo apt-get update -qq
-  - sudo apt-get install libzmq3
-  - sudo apt-get install libzmq3-dev

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.1.0
+
+* Update Faraday dependency to ~> 0.9
+
 # 0.0.1
 
 * Initial Release

--- a/farscape.gemspec
+++ b/farscape.gemspec
@@ -3,7 +3,7 @@ require 'farscape/version'
 
 Gem::Specification.new do |s|
   s.name          = 'farscape'
-  s.version       = Farscape::VERSION::STRING
+  s.version       = Farscape::VERSION
   s.date          = Time.now.strftime('%Y-%m-%d')
   s.summary       = 'It shoots through wormholes and takes you to unknown places in the universe!'
   s.homepage      = 'https://github.com//farscape'
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'dice_bag'
   s.add_dependency 'rake'
   s.add_dependency('addressable',   '~> 2.3.0')
-  s.add_dependency('faraday',       '~> 0.8.8')
+  s.add_dependency('faraday',       '~> 0.9')
   s.add_dependency('activesupport', '>= 0')
 
   s.add_development_dependency 'rspec'

--- a/lib/farscape/version.rb
+++ b/lib/farscape/version.rb
@@ -1,12 +1,6 @@
 # Used to prevent the class/module from being loaded more than once
 unless defined?(::Farscape::VERSION)
   module Farscape
-    module VERSION
-      MAJOR = 1
-      MINOR = 0
-      TINY  = 1
-
-      STRING = [MAJOR, MINOR, TINY].join('.')
-    end
+    VERSION = '1.1.0'.freeze
   end
 end


### PR DESCRIPTION
Update Faraday <s>version</s> dependency from '~> 0.8.8' to '~> 0.9', to solve conflict with [eureka-client](https://github.com/mdsol/eureka-client/blob/develop/eureka-client.gemspec#L27)

<s>Also update bundler in `.travis.yml` to fix following Travis CI issue

```
NoMethodError: undefined method `spec' for nil:NilClass
```

https://github.com/travis-ci/travis-ci/issues/3531</s>

[Update] Removed Ruby 1.9 from .travis.yml so it's not necessary to update bundler

@mdsol/team-10 please review
