### PR TITLE
prevent crash when an embedded resource is not an enumerable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,11 @@
-# 1.1.1
+# 1.1.2
+* Prevent crash when an embedded resource is not an enumerable
 
+# 1.1.1
 * Add POST method support
 
 # 1.1.0
-
 * Update Faraday dependency to ~> 0.9
 
 # 0.0.1
-
 * Initial Release

--- a/lib/farscape/representor.rb
+++ b/lib/farscape/representor.rb
@@ -4,9 +4,9 @@ require 'ostruct'
 
 module Farscape
   class SafeRepresentorAgent
-    
+
     include BaseAgent
-    
+
     attr_reader :agent
     attr_reader :representor
     attr_reader :response
@@ -20,7 +20,7 @@ module Farscape
       @representor = deserialize(requested_media_type, response.body)
       handle_extensions
     end
-    
+
     %w(using omitting).each do |meth|
       define_method(meth) { |name_or_type| self.class.new(@requested_media_type, @response, @agent.send(meth, name_or_type)) }
     end
@@ -64,6 +64,7 @@ module Farscape
     end
 
     def _embedded(reprs, response)
+      reprs = [reprs] unless reprs.respond_to?(:map)
       reprs.map { |repr| @agent.representor.new(false, OpenStruct.new(status: response.status, headers: response.headers, body: repr), @agent) }
     end
 

--- a/lib/farscape/version.rb
+++ b/lib/farscape/version.rb
@@ -1,6 +1,6 @@
 # Used to prevent the class/module from being loaded more than once
 unless defined?(::Farscape::VERSION)
   module Farscape
-    VERSION = '1.1.1'.freeze
+    VERSION = '1.1.2'.freeze
   end
 end


### PR DESCRIPTION
when an embedded resources' size is 1 it can be just an object, failing miserably when we try to call `map` on it...

@mdsol/team-10 
