### PR TITLE
[MCC-224202] add support for templated URIs and POST requests

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,0 @@
---color
---format documentation

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,8 @@ cache: bundler
 sudo: false
 
 rvm:
-  - 2.1.8
-  - 2.2.4
-  - 2.3.0
+  - 2.1.10
+  - 2.2.5
+  - 2.3.1
+
 script: "bundle exec rspec"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.2.0
+* Add support for templated URIs and POST requests
+
 # 1.1.2
 * Prevent crash when an embedded resource is not an enumerable
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,23 +1,6 @@
 source 'https://rubygems.org'
+
 gemspec
 
-gem 'byebug', '~> 3.5.1' if RUBY_VERSION > '2'
-gem 'yard',          '~> 0.8.5'
-gem 'rake',          '~> 0.9'
-gem 'awesome_print', '~> 1.1.0'
-gem 'redcarpet'
-
-gem 'representors', git: 'https://www.github.com/mdsol-share/representors.git', branch: '0-0-stable'
-
-group :development, :test do
-  gem 'pry'
-  #TODO replace both crichton and crichton_test_service with references to stable branches when ready.
-  gem 'moya', git: 'https://www.github.com/mdsol/moya.git', branch: 'develop'
-  gem 'crichton', git: 'https://www.github.com/mdsol-share/crichton.git', branch: 'develop'
-end
-
-group :test do
-  gem 'webmock',        '~> 1.13.0'
-  gem 'rspec',          '~> 2.14'
-  gem 'simplecov',      '~> 0.7'
-end
+gem 'crichton', git: 'https://github.com/mdsol-share/crichton.git', branch: 'develop'
+gem 'moya', git: 'https://github.com/mdsol/moya.git', branch: 'develop'

--- a/farscape.gemspec
+++ b/farscape.gemspec
@@ -4,9 +4,10 @@ require 'farscape/version'
 Gem::Specification.new do |s|
   s.name          = 'farscape'
   s.version       = Farscape::VERSION
+  s.license       = 'MIT'
   s.date          = Time.now.strftime('%Y-%m-%d')
   s.summary       = 'It shoots through wormholes and takes you to unknown places in the universe!'
-  s.homepage      = 'https://github.com//farscape'
+  s.homepage      = 'https://github.com/mdsol/farscape'
   s.email         = ''
   s.authors       = ['Mark W. Foster']
   s.files         = ['lib/**/*', 'spec/**/*', 'tasks/**/*', '[A-Z]*'].map { |glob| Dir[glob] }.inject([], &:+)
@@ -17,12 +18,15 @@ Gem::Specification.new do |s|
     Farscape is a library that simplifies consuming Hypermedia API responses.
   DESC
 
-  s.add_dependency 'dice_bag'
+  s.add_dependency 'activesupport'
+  s.add_dependency 'addressable', '~> 2.3'
+  s.add_dependency 'faraday', '~> 0.9'
   s.add_dependency 'rake'
-  s.add_dependency('addressable',   '~> 2.3.0')
-  s.add_dependency('faraday',       '~> 0.9')
-  s.add_dependency('activesupport', '>= 0')
+  s.add_dependency 'representors', '~> 0.0.5'
 
-  s.add_development_dependency 'rspec'
-
+  s.add_development_dependency 'byebug'
+  s.add_development_dependency 'redcarpet', '~> 3.3'
+  s.add_development_dependency 'rspec', '~> 2.14'
+  s.add_development_dependency 'simplecov', '~> 0.11'
+  s.add_development_dependency 'yard'
 end

--- a/lib/farscape/version.rb
+++ b/lib/farscape/version.rb
@@ -1,6 +1,6 @@
 # Used to prevent the class/module from being loaded more than once
 unless defined?(::Farscape::VERSION)
   module Farscape
-    VERSION = '1.1.2'.freeze
+    VERSION = '1.2.0'.freeze
   end
 end

--- a/spec/lib/farscape/plugins_spec.rb
+++ b/spec/lib/farscape/plugins_spec.rb
@@ -14,7 +14,7 @@ module TestMiddleware
       end
     end
   end
- 
+
   class Saboteur
     def initialize(app, *)
       @app = app
@@ -38,21 +38,21 @@ module TestMiddleware
 end
 
 describe Farscape::Agent do
-  
-  before(:each) do 
-    Farscape.clear 
+
+  before(:each) do
+    Farscape.clear
     detector_plugin = {name: :Detector, type: :sebacean, middleware: [TestMiddleware::SabotageDetector], default_state: :disabled}
     saboteur_middleware = {class: TestMiddleware::Saboteur, before: :sebacean}
     saboteur_plugin = {name: :Saboteur, type: :scarran, middleware: [saboteur_middleware]}
     Farscape.register_plugin(detector_plugin)
     Farscape.register_plugin(saboteur_plugin)
   end
-  
+
   after(:all) { Farscape.clear }
-  
+
   let(:entry_point) { "http://localhost:#{RAILS_PORT}"}
   let(:can_do_hash) { {conditions: 'can_do_anything'} }
-  
+
   it 'accepts a using directive that enables a plugin' do
     expect { Farscape::Agent.new(entry_point).using(:Detector).enter }.to raise_error('Sabotage detected')
   end
@@ -60,8 +60,7 @@ describe Farscape::Agent do
   it 'accepts an omitting directive that disables a plugin' do
     agent = Farscape::Agent.new(entry_point).using(:Detector)
     agent = agent.omitting(:sebacean)
-    
-    expect { agent.enter }.to_not raise_error('Sabotage detected')
+    expect { agent.enter }.to_not raise_error
   end
 
   it 'allows showing the list of registered plugins' do
@@ -73,31 +72,31 @@ describe Farscape::Agent do
     expect(agent.enabled_plugins[:Detector]).to_not be_nil
     expect(Farscape.disabled_plugins[:Detector]).to_not be_nil
   end
-  
+
   it 'allows showing only those disabled for the agent' do
     agent = Farscape::Agent.new(entry_point).using(:Detector)
     agent = agent.omitting(:sebacean)
     expect(agent.disabled_plugins.keys).to eq([:Detector])
-    expect(Farscape.enabled_plugins.keys).to eq([:Saboteur])   
+    expect(Farscape.enabled_plugins.keys).to eq([:Saboteur])
   end
-  
+
   it 'allows using on TransitionAgent objects' do
     transition = Farscape::Agent.new(entry_point).enter.transitions["drds"].using(:Detector)
-    expect { transition.invoke { |req| req.parameters = can_do_hash } }.to raise_error('Sabotage detected')  
+    expect { transition.invoke { |req| req.parameters = can_do_hash } }.to raise_error('Sabotage detected')
     expect(transition.disabled_plugins).to eq({})
   end
-  
+
   it 'allows using on RepresentorAgent objects' do
     representor = Farscape::Agent.new(entry_point).enter.using(:Detector)
     transition = representor.transitions["drds"]
     expect { transition.invoke { |req| req.parameters = can_do_hash } }.to raise_error('Sabotage detected')
     expect(representor.disabled_plugins).to eq({})
   end
-  
+
 end
 
 describe Farscape do
-  after(:all) { Farscape.clear }  
+  after(:all) { Farscape.clear }
 
   context 'configuring plugins' do
 
@@ -114,8 +113,8 @@ describe Farscape do
       plugin = {name: :Peacekeeper, type: :sebacean}
       Farscape.register_plugin(plugin)
       expect(Farscape.enabled_plugins).to be_empty
-      expect(Farscape.disabled?(plugin)).to be_true
-      expect(Farscape.enabled?(plugin)).to be_false
+      expect(Farscape.disabled?(plugin)).to be true
+      expect(Farscape.enabled?(plugin)).to be false
     end
 
     it 'can preemptively disable a plugin by type' do
@@ -123,8 +122,8 @@ describe Farscape do
       plugin = {name: :Peacekeeper, type: :sebacean}
       Farscape.register_plugin(plugin)
       expect(Farscape.enabled_plugins).to be_empty
-      expect(Farscape.disabled?(plugin)).to be_true
-      expect(Farscape.enabled?(plugin)).to be_false
+      expect(Farscape.disabled?(plugin)).to be true
+      expect(Farscape.enabled?(plugin)).to be false
     end
 
     it "can disable a plugin after it's added" do
@@ -133,16 +132,16 @@ describe Farscape do
       Farscape.disable!(:sebacean)
       expect(Farscape.enabled_plugins).to be_one
     end
-    
+
     context 'adding middleware' do
-      
+
       before(:each) { Farscape.clear }
       after(:all) { Farscape.clear }
-      
+
       it 'can add middleware' do
         plugin = {name: :Peacekeeper, type: :sebacean, middleware: [TestMiddleware::NoGetNoProblem]}
         Farscape.register_plugin(plugin)
-        
+
         expect(Farscape.middleware_stack.map{ |elt| elt[:class] } ).to eq([TestMiddleware::NoGetNoProblem])
       end
 
@@ -150,28 +149,28 @@ describe Farscape do
         plugin = {name: :Peacekeeper, type: :sebacean, middleware: [TestMiddleware::NoGetNoProblem]}
         Farscape.register_plugin(plugin)
         Farscape.disable!( :sebacean )
-        
+
         expect(Farscape.middleware_stack).to be_none
       end
 
       it 'uses the middleware when making requests' do
         plugin = {name: :Peacekeeper, type: :sebacean, middleware: [TestMiddleware::NoGetNoProblem]}
         Farscape.register_plugin(plugin)
-        
+
         expect{Farscape::Agent.new("http://localhost:#{RAILS_PORT}").enter}.to raise_error('Shazam!')
       end
 
       it 'can configure middleware' do
         plugin = {name: :Peacekeeper, type: :sebacean, middleware: [{class: TestMiddleware::NoGetNoProblem, config: {permissive: true}}]}
         Farscape.register_plugin(plugin)
-        
-        expect{Farscape::Agent.new("http://localhost:#{RAILS_PORT}").enter}.not_to raise_error('Shazam!')
+
+        expect{Farscape::Agent.new("http://localhost:#{RAILS_PORT}").enter}.not_to raise_error
       end
 
       it 'adds middleware to disabled when disabled' do
           plugin = {name: :Peacekeeper, default_state: :disabled, type: :sebacean, middleware: [{class: TestMiddleware::NoGetNoProblem, config: {permissive: true}}]}
           Farscape.register_plugin(plugin)
-          
+
           expect(Farscape.enabled_plugins).to eq({})
           expect(Farscape.disabled_plugins).to eq(plugin[:name] => plugin)
       end
@@ -182,7 +181,7 @@ describe Farscape do
           saboteur_plugin = {name: :Saboteur, type: :scarran, middleware: [saboteur_middleware]}
           detector_plugin = {name: :Detector, type: :sebacean, middleware: [TestMiddleware::SabotageDetector]}
           [saboteur_plugin, detector_plugin].shuffle.each { |plugin| Farscape.register_plugin(plugin) }
-          
+
           expect(Farscape.middleware_stack.map{ |m| m[:class] }).to eq( [TestMiddleware::Saboteur, TestMiddleware::SabotageDetector] )
           expect{Farscape::Agent.new("http://localhost:#{RAILS_PORT}").enter}.to raise_error('Sabotage detected')
         end
@@ -194,31 +193,31 @@ describe Farscape do
           saboteur_plugin = {name: :Saboteur, type: :scarran, middleware: [saboteur_middleware]}
           detector_plugin = {name: :Detector, type: :sebacean, middleware: [TestMiddleware::SabotageDetector]}
           [saboteur_plugin, detector_plugin].shuffle.each { |plugin| Farscape.register_plugin(plugin) }
-          
+
           expect(Farscape.middleware_stack.map{ |m| m[:class] }).to eq( [TestMiddleware::SabotageDetector, TestMiddleware::Saboteur] )
-          expect{Farscape::Agent.new("http://localhost:#{RAILS_PORT}").enter}.not_to raise_error('Sabotage detected')
+          expect{Farscape::Agent.new("http://localhost:#{RAILS_PORT}").enter}.not_to raise_error
         end
       end
-      
+
       it 'doesn\'t disable everything with one' do
         detector_plugin = {name: :Detector, type: :sebacean, middleware: [TestMiddleware::SabotageDetector], default_state: :disabled}
         saboteur_middleware = {class: TestMiddleware::Saboteur}
         saboteur_plugin = {name: :Saboteur, type: :scarran, middleware: [saboteur_middleware]}
         Farscape.register_plugin(detector_plugin)
         Farscape.register_plugin(saboteur_plugin)
-        
+
         expect(Farscape.enabled_plugins.keys).to eq([:Saboteur])
       end
 
       it 'doesn\'t allow sneaky enabling' do
         detector_plugin = {name: :Detector, type: :sebacean, middleware: [TestMiddleware::SabotageDetector], default_state: :disabled}
         Farscape.register_plugin(detector_plugin)
-        
+
         expect(Farscape.disabled_plugins.keys).to eq([:Detector])
-        
+
         detector_plugin = {name: :Detector, type: :sebacean, middleware: [TestMiddleware::SabotageDetector], default_state: :enabled}
         Farscape.register_plugin(detector_plugin)
-        
+
         expect(Farscape.disabled_plugins.keys).to eq([:Detector])
       end
 
@@ -227,10 +226,10 @@ describe Farscape do
     context 'extensions' do
       before(:each) { Farscape.clear }
       after(:all) { Farscape.clear }
-        
+
       let(:entry_point) { "http://localhost:#{RAILS_PORT}"}
       let(:can_do_hash) { {conditions: 'can_do_anything'} }
-      
+
       it 'allows extensions' do
         module Peacekeeper
           def pacify!
@@ -240,7 +239,7 @@ describe Farscape do
         Farscape.register_plugin(name: :Peacekeeper, type: :security, extensions: {Agent: [Peacekeeper]})
         expect { Farscape::Agent.new.pacify! }.to raise_error('none shall pass')
       end
-      
+
       it 'allows extensions with altering existing methods' do
         module Peacemaker
           def self.extended(base)
@@ -257,7 +256,7 @@ describe Farscape do
         expect { Farscape::Agent.new.enter(entry_point).transitions.keys }.to raise_error('none shall pass')
         expect(Farscape::Agent.new.enter(entry_point).omitting(:Peacekeeper).transitions.keys).to include("drds")
       end
-      
+
       it 'allows discovery extensions' do
         module ServiceCatalogue
           def self.extended(base)
@@ -271,7 +270,7 @@ describe Farscape do
                 @entry_point = @dispatches[@entry_point] || @entry_point
                 @original_enter.call
               end
-            end            
+            end
           end
         end
         Farscape.register_plugin(name: :Wormlet, type: :discovery, extensions: {Agent: [ServiceCatalogue]})
@@ -279,65 +278,65 @@ describe Farscape do
         expect(Farscape::Agent.new.enter(:moya).transitions.keys).to include("drds")
         expect { Farscape::Agent.new.omitting(:discovery).enter(:moya).transitions.keys }.to raise_error(NoMethodError)
       end
-      
+
     end
 
     context 'workflow' do
-      
+
       before(:each) { Farscape.clear }
-      
+
       let(:entry_point) { "http://localhost:#{RAILS_PORT}"}
       let(:can_do_hash) { {conditions: 'can_do_anything'} }
-      
+
       it 'manages enabling and disabling plugins' do
         registration = [{name: :Peacekeeper, type: :sebacean, middleware: [TestMiddleware::NoGetNoProblem]}]
         registration_keys = registration.map { |plugin| plugin[:name] }
         Farscape.register_plugins(registration)
-        
+
         expect(Farscape.plugins.keys).to eq( registration_keys )
         expect(Farscape.enabled_plugins.keys).to eq( registration_keys )
         expect(Farscape.disabled_plugins.keys).to eq([])
-        
+
         Farscape.disable!(type: :sebacean)
-        
+
         expect(Farscape.enabled_plugins.keys).to eq([])
         expect(Farscape.disabled_plugins.keys).to eq( registration_keys )
-        
+
         Farscape.enable!(name: :Peacekeeper)
-        
+
         expect(Farscape.enabled_plugins.keys).to eq( registration_keys )
         expect(Farscape.disabled_plugins.keys).to eq([])
       end
-      
+
       it 'managed complex enabling and disabling on instances' do
         registration = [{name: :Peacekeeper, type: :sebacean, middleware: [TestMiddleware::NoGetNoProblem]}]
         registration_keys = registration.map { |plugin| plugin[:name] }
         Farscape.register_plugins(registration)
         peacekeeper_plugin = {:Peacekeeper=>{:name=>:Peacekeeper, :type=>:sebacean, :middleware=>[TestMiddleware::NoGetNoProblem], :enabled=>true}}
         disabled_plugin = {:Peacekeeper=>{:name=>:Peacekeeper, :type=>:sebacean, :middleware=>[TestMiddleware::NoGetNoProblem], :enabled=>false}}
-        
+
         expect(Farscape.enabled_plugins).to eq(peacekeeper_plugin)
-        
+
         agent = Farscape::Agent.new.omitting(name: :Peacekeeper)
-        
+
         expect(agent.plugins).to eq(disabled_plugin)
         expect(agent.enabled_plugins).to eq({})
         expect(agent.disabled_plugins).to eq(disabled_plugin)
-        
+
         resource = agent.enter(entry_point).transitions["drds"].invoke { |builder| builder.parameters = can_do_hash }
         expect(resource.plugins).to eq(disabled_plugin)
         expect(resource.enabled_plugins).to eq({})
         expect(resource.plugins).to eq(disabled_plugin)
-        
+
         transition = resource.using(name: :Peacekeeper).transitions["items"]
         details = resource.using(name: :Peacekeeper).embedded["items"].first
-        
+
         expect { transition.invoke }.to raise_error('Shazam!')
         expect(details.plugins).to eq(peacekeeper_plugin)
         expect(details.enabled_plugins).to eq(peacekeeper_plugin)
         expect(details.disabled_plugins).to eq({})
       end
-            
+
     end
 
   end

--- a/spec/lib/farscape/transition_spec.rb
+++ b/spec/lib/farscape/transition_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe Farscape::TransitionAgent do
   let(:client) { double }
   let(:agent) { double(media_type: :hale, client: client) }
-  let(:transition) { double(uri: 'com:mdsol') }
+  let(:transition) { double(uri: 'com:mdsol', templated?: false) }
   let(:arg) { { additional_fields: { key1: 'value1', key2: 'value2' } } }
   let(:transition_agent) { described_class.new(transition, agent) }
   let(:field_list) { double(name: 'additional_fields') }
@@ -12,30 +12,68 @@ describe Farscape::TransitionAgent do
   before do
     allow(agent).to receive(:get_accept_header).and_return(Accept: 'application/vnd.hale+json')
     allow(agent).to receive(:find_exception).and_return(nil)
+    allow(transition).to receive(:interface_method).and_return(http_method)
     allow(transition).to receive(:parameters).and_return([ field_list ])
     allow(transition).to receive(:attributes).and_return([])
     allow_any_instance_of(described_class).to receive(:handle_extensions).and_return(nil)
   end
 
   context 'GET method' do
-    before do
-      allow(transition).to receive(:interface_method).and_return('get')
-    end
+    let(:http_method) { "get" }
 
     it 'stores parameters in params' do
-      expect(client).to receive(:invoke).with(call_options.merge(method: 'get', params: arg))
+      expect(client).to receive(:invoke).with(call_options.merge(method: http_method, params: arg))
       transition_agent.invoke(arg)
     end
   end
 
   context 'POST method' do
-    before do
-      allow(transition).to receive(:interface_method).and_return('post')
-    end
+    let(:http_method) { "post" }
 
     it 'stores parameters in body' do
-      expect(client).to receive(:invoke).with(call_options.merge(method: 'post', body: arg))
+      expect(client).to receive(:invoke).with(call_options.merge(method: http_method, body: arg))
       transition_agent.invoke(arg)
+    end
+  end
+
+  # see https://tools.ietf.org/html/rfc6570#section-3.2.6
+  context "URL with a path segment" do
+    let(:transition) do
+      Representors::Transition.new(
+        templated: true,
+        rel: "find",
+        href: "https://example.com/api/v1/issues{/issue_uuid}"
+      )
+    end
+    let(:issue_uuid) { SecureRandom.uuid }
+
+    context "GET" do
+      let(:http_method) { "get" }
+
+      it "interpolates a templated URI" do
+        options = call_options.merge(
+          method: http_method,
+          url: "https://example.com/api/v1/issues/#{issue_uuid}",
+          params: arg
+        )
+        expect(client).to receive(:invoke).with(options)
+        transition_agent.invoke(arg.merge(issue_uuid: issue_uuid))
+      end
+    end
+
+    context "POST" do
+      let(:http_method) { "post" }
+
+      it "does not interpolate a templated URI" do
+        params = arg.merge(issue_uuid: issue_uuid)
+        options = call_options.merge(
+          method: http_method,
+          url: "https://example.com/api/v1/issues",
+          body: params
+        )
+        expect(client).to receive(:invoke).with(options)
+        transition_agent.invoke(params)
+      end
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,21 +1,15 @@
-RAILS_PORT = 1234
-SPEC_DIR = File.expand_path("..", __FILE__)
-lib_dir = File.expand_path("../lib", SPEC_DIR)
-
-
-$LOAD_PATH.unshift(lib_dir)
-$LOAD_PATH.uniq!
-
-require 'rspec'
-require 'pry'
-require 'bundler'
 require 'simplecov'
+SimpleCov.start
+
+require 'crichton'
+require 'representors'
 require 'moya'
 
-SimpleCov.start
-Bundler.setup
-
+RAILS_PORT = 1234
+SPEC_DIR = File.expand_path("..", __FILE__)
+$LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'farscape'
+
 Dir["#{SPEC_DIR}/support/*.rb"].each { |f| require f }
 
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration


### PR DESCRIPTION
Basically a fusion of a few hack branches we had to address specific shortcomings.

As we're at it,
- depend on representors that has just been published to rubygems.org
- clean up the Gemfile & gemspec

@mdsol/team-10 
