### PR TITLE
[MCC-233038] adds discover and config methods to the farscape agent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ coverage
 tmp
 .yardoc
 yardoc
+.byebug_history

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.3.0
+* Add discover method and configuration to the Farscape agent.
+
 # 1.2.0
 * Add support for templated URIs and POST requests
 

--- a/farscape.gemspec
+++ b/farscape.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'byebug'
   s.add_development_dependency 'redcarpet', '~> 3.3'
   s.add_development_dependency 'rspec', '~> 2.14'
+  s.add_development_dependency 'webmock', '~> 2.0'
   s.add_development_dependency 'simplecov', '~> 0.11'
   s.add_development_dependency 'yard'
 end

--- a/lib/farscape/discovery.rb
+++ b/lib/farscape/discovery.rb
@@ -1,0 +1,32 @@
+module Farscape
+  # This class provide discovery capabilities to Farscape.
+  class Discovery
+
+    DISCOVERY_KEY = :discovery_uri
+
+    class NotFound < NameError
+    end
+
+    # This is the simplest type of discovery. We assume that the url we will call will provide us
+    # document with links which keys are the names we want to discover and hrefs are root URLS.
+    # Templated URLs are supported, an exception will be raised if the template does not match the variables.
+    #       {
+    #        "_links": {
+    #          "boxes": { "href": "https://smallboxesandpoliceboxes.com" },
+    #          "items": { "href": "https://sonicscrewdriversandotherthings.com/v1/{item}" }
+    #        }
+    #      }
+    def discover(config, key, url_template_variables)
+      discovery_uri = config[DISCOVERY_KEY]
+      raise NotFound, "No discovery uri setup for Farscape. Discovery of #{key} unavailable" unless discovery_uri
+      raise NotFound, "Discover URL #{discovery_uri} is not a valid URL." unless discovery_uri =~ URI::regexp
+      discovery_document = Farscape::Agent.new(discovery_uri).enter
+      if discovery_document.kind_of?(Faraday::Response) # Parse errors give us a raw Faraday Response
+        raise NotFound, "The discovery document for #{key} is not valid JSON. We got: #{discovery_document.body}"
+      end
+      found = discovery_document.transitions[key.to_s]
+      raise NotFound, "No key '#{key}' found in the response from the discovery service." unless found
+      found.uri(url_template_variables)
+    end
+  end
+end

--- a/lib/farscape/version.rb
+++ b/lib/farscape/version.rb
@@ -1,6 +1,6 @@
 # Used to prevent the class/module from being loaded more than once
 unless defined?(::Farscape::VERSION)
   module Farscape
-    VERSION = '1.2.0'.freeze
+    VERSION = '1.3.0'.freeze
   end
 end

--- a/spec/lib/farscape/agent_spec.rb
+++ b/spec/lib/farscape/agent_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+describe Farscape::Agent do
+  describe '#instance' do
+    it 'returns an Farscape::Agent object' do
+      expect(described_class.instance.class).to eq(described_class)
+    end
+
+    it 'returns the same agent if called twice' do
+      agent1 = described_class.instance
+      expect(described_class.instance).to eq(agent1)
+    end
+  end
+
+  describe '#config' do
+    it 'defaults to an empty hash' do
+      expect(described_class.config).to eq({})
+    end
+
+    it 'can be set' do
+      described_class.config = { me: 'too' }
+      expect(described_class.config).to eq( me: 'too' )
+      described_class.config = nil
+    end
+  end
+end

--- a/spec/lib/farscape/plugins_spec.rb
+++ b/spec/lib/farscape/plugins_spec.rb
@@ -276,7 +276,6 @@ describe Farscape do
         Farscape.register_plugin(name: :Wormlet, type: :discovery, extensions: {Agent: [ServiceCatalogue]})
         expect(Farscape::Agent.new(:moya).enter.transitions.keys).to include("drds")
         expect(Farscape::Agent.new.enter(:moya).transitions.keys).to include("drds")
-        expect { Farscape::Agent.new.omitting(:discovery).enter(:moya).transitions.keys }.to raise_error(NoMethodError)
       end
 
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,12 +5,18 @@ require 'crichton'
 require 'representors'
 require 'moya'
 
+require 'webmock/rspec'
+
+
 RAILS_PORT = 1234
 SPEC_DIR = File.expand_path("..", __FILE__)
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'farscape'
 
 Dir["#{SPEC_DIR}/support/*.rb"].each { |f| require f }
+
+
+WebMock.disable_net_connect!(allow_localhost: true)
 
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|


### PR DESCRIPTION
The idea is to have a very simple way of discovering resources.  Should help simplify usage of Farscape in different codebases by having this in the agent.
Also added a instance method to the agent to easily get thread-safe versions of it

@mdsol/team-10  @HonoreDB please review
