### PR TITLE
[MCC-202013] Update to make GET request query in lowercase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.3.3
+* Update to make GET request query in lowercase.
+
 # 1.3.2
 * Add support for use of JSON in request body.
 

--- a/lib/farscape/transition.rb
+++ b/lib/farscape/transition.rb
@@ -27,7 +27,13 @@ module Farscape
 
       if call_options[:method].downcase == 'get'
         # delegate the URL building to representors so we can use templated URIs
-        call_options[:url] = @transition.uri(params)
+
+        # We are in another unfortunate situation in which Mauth-client might not be able to validate
+        # if a request query string contains uppercase characters.
+        # Somebody, probably Nginx, converts the query string to lowercase, and Mauth-client uses it
+        # to compare with the signature which is generated using the original query string.
+        # https://github.com/mdsol/mauth-client-ruby/blob/v4.0.1/lib/mauth/client.rb#L333
+        call_options[:url] = @transition.uri(params).downcase
         # still need to use this for extra params... (e.g. "conditions=can_do_anything")
         if params.present?
           if @transition.templated?

--- a/lib/farscape/version.rb
+++ b/lib/farscape/version.rb
@@ -1,6 +1,6 @@
 # Used to prevent the class/module from being loaded more than once
 unless defined?(::Farscape::VERSION)
   module Farscape
-    VERSION = '1.3.2'.freeze
+    VERSION = '1.3.3'.freeze
   end
 end

--- a/spec/lib/farscape/transition_spec.rb
+++ b/spec/lib/farscape/transition_spec.rb
@@ -50,14 +50,14 @@ describe Farscape::TransitionAgent do
     context "GET" do
       let(:http_method) { "get" }
 
-      it "interpolates a templated URI" do
+      it "interpolates a templated URI in lowercase" do
         options = call_options.merge(
           method: http_method,
           url: "https://example.com/api/v1/issues/#{issue_uuid}",
           params: arg
         )
         expect(client).to receive(:invoke).with(options)
-        transition_agent.invoke(arg.merge(issue_uuid: issue_uuid))
+        transition_agent.invoke(arg.merge(issue_uuid: issue_uuid.upcase))
       end
     end
 


### PR DESCRIPTION
When making an API call using GET request with encoded Japanese in uppercase (e.g. `http://example.org/v2/regions/codes/%E6%9D%B1%E4%BA%AC`), the server side Mauth-client cannot validate the request.

Nginx is suspicious, seems to convert the encoded string to lowercase, but we haven't found the root cause yet.

Mauth-client uses the query string in lowercase to compare with the signature which is generated using the original query string, and they won't match.

This PR is to make GET request query in lowercase.

Adhoc'd in Hippocrates and Polybus

@mdsol/team-10 
